### PR TITLE
EZP-30224: Make `ez_user_settings` twig global load user settings dynamically

### DIFF
--- a/src/bundle/Resources/config/services/user_settings.yml
+++ b/src/bundle/Resources/config/services/user_settings.yml
@@ -8,6 +8,13 @@ services:
         resource: "../../../lib/UserSetting/*"
 
     #
+    # Main Service
+    #
+    EzSystems\EzPlatformUser\UserSetting\UserSettingService: ~
+
+    EzSystems\EzPlatformUser\UserSetting\UserSettingArrayAccessor:
+
+    #
     # User Settings Implementations
     #
     EzSystems\EzPlatformUser\UserSetting\Setting\Timezone:

--- a/src/lib/UserSetting/UserSetting.php
+++ b/src/lib/UserSetting/UserSetting.php
@@ -10,6 +10,12 @@ namespace EzSystems\EzPlatformUser\UserSetting;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
 
+/**
+ * @property string $identifier
+ * @property string $name
+ * @property string $description
+ * @property string $value
+ */
 class UserSetting extends ValueObject
 {
     /** @var string */

--- a/src/lib/UserSetting/UserSettingArrayAccessor.php
+++ b/src/lib/UserSetting/UserSettingArrayAccessor.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUser\UserSetting;
+
+use ArrayAccess;
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
+
+/**
+ * @internal
+ */
+class UserSettingArrayAccessor implements ArrayAccess
+{
+    /** @var \EzSystems\EzPlatformUser\UserSetting\UserSettingService */
+    protected $userSettingService;
+
+    /**
+     * @param \EzSystems\EzPlatformUser\UserSetting\UserSettingService $userSettingService
+     */
+    public function __construct(UserSettingService $userSettingService)
+    {
+        $this->userSettingService = $userSettingService;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($offset): bool
+    {
+        // @todo refactor once UserSettingService supports this natively
+
+        return null !== $this->userSettingService->getUserSetting($offset);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset): string
+    {
+        return $this->userSettingService->getUserSetting($offset)->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetSet($offset, $value): void
+    {
+        $this->userSettingService->setUserSetting($offset, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetUnset($offset): void
+    {
+        // UserSettingService doesn't provide this feature
+
+        throw new NotImplementedException('offsetUnset');
+    }
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-30224

It exposes `UserSettingArrayAccessor` which can be used to access User Settings in array-like fashion. This is solely to provide BC compatibility in AdminUI `ez_user_settings` Twig global variable which is an array.