### PR TITLE
EZP-30099: Lazy initialize date formatters in \EzSystems\EzPlatformUser\Templating\Twig\DateTimeExtension

### DIFF
--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -53,5 +53,6 @@ services:
             - { name: kernel.event_subscriber }
 
     EzSystems\EzPlatformUser\Templating\Twig\DateTimeExtension:
+        lazy: true
         tags:
             - { name: twig.extension }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30099](https://jira.ez.no/browse/EZP-30099)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | ?
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Follow up for the https://github.com/ezsystems/ezplatform-user/pull/11. Too early access to the `language`  preference might cause https://travis-ci.org/ezsystems/ezplatform-admin-ui/jobs/502193197.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review