### PR TITLE
Added configuration for the jms_translation extension

### DIFF
--- a/src/bundle/DependencyInjection/EzPlatformUserExtension.php
+++ b/src/bundle/DependencyInjection/EzPlatformUserExtension.php
@@ -10,20 +10,16 @@ namespace EzSystems\EzPlatformUserBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-class EzPlatformUserExtension extends Extension
+class EzPlatformUserExtension extends Extension implements PrependExtensionInterface
 {
     /**
-     * Loads a specific configuration.
-     *
-     * @param array $configs An array of configuration values
-     * @param ContainerBuilder $container A ContainerBuilder instance
-     *
-     * @throws \InvalidArgumentException When provided tag is not defined in this extension
+     * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader(
             $container,
@@ -31,5 +27,33 @@ class EzPlatformUserExtension extends Extension
         );
 
         $loader->load('services.yml');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepend(ContainerBuilder $container): void
+    {
+        $this->prependJMSTranslation($container);
+    }
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function prependJMSTranslation(ContainerBuilder $container): void
+    {
+        $container->prependExtensionConfig('jms_translation', [
+            'configs' => [
+                'ezplatform_user' => [
+                    'dirs' => [
+                        __DIR__ . '/../../',
+                    ],
+                    'output_dir' => __DIR__ . '/../Resources/translations/',
+                    'output_format' => 'xliff',
+                    'excluded_dirs' => ['tests'],
+                    'extractors' => [],
+                ],
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
> JIRA: -

## Description

Added configuration for the `jms_translation` extension. Thanks to this translations could be easily extracted via:

```bash
php bin/console translation:extract -c ezplatform_user
```