### PR TITLE
EZP-30253: Reorder the "My Preferences" options under User settings

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/UserSetting/ValueDefinitionPass.php
+++ b/src/bundle/DependencyInjection/Compiler/UserSetting/ValueDefinitionPass.php
@@ -43,7 +43,11 @@ class ValueDefinitionPass implements CompilerPassInterface
                     );
                 }
 
-                $registryDefinition->addMethodCall('addValueDefinition', [$tag['identifier'], new Reference($taggedServiceId)]);
+                $registryDefinition->addMethodCall('addValueDefinition', [
+                    $tag['identifier'],
+                    new Reference($taggedServiceId),
+                    $tag['priority'] ?? 0,
+                ]);
             }
         }
     }

--- a/src/bundle/Resources/config/services/user_settings.yml
+++ b/src/bundle/Resources/config/services/user_settings.yml
@@ -19,34 +19,34 @@ services:
     #
     EzSystems\EzPlatformUser\UserSetting\Setting\Timezone:
         tags:
-            - { name: ezplatform.admin_ui.user_setting.value, identifier: timezone }
+            - { name: ezplatform.admin_ui.user_setting.value, identifier: timezone, priority: 50 }
             - { name: ezplatform.admin_ui.user_setting.form_mapper, identifier: timezone }
 
     EzSystems\EzPlatformUser\UserSetting\Setting\SubitemsLimit:
         arguments:
             $subitemsLimit: '$subitems_module.limit$'
         tags:
-            - { name: ezplatform.admin_ui.user_setting.value, identifier: subitems_limit }
+            - { name: ezplatform.admin_ui.user_setting.value, identifier: subitems_limit, priority: 20 }
             - { name: ezplatform.admin_ui.user_setting.form_mapper, identifier: subitems_limit }
 
     EzSystems\EzPlatformUser\UserSetting\Setting\CharacterCounter:
         tags:
-            - { name: ezplatform.admin_ui.user_setting.value, identifier: character_counter }
+            - { name: ezplatform.admin_ui.user_setting.value, identifier: character_counter, priority: 10 }
             - { name: ezplatform.admin_ui.user_setting.form_mapper, identifier: character_counter }
 
     EzSystems\EzPlatformUser\UserSetting\Setting\FullDateTimeFormat:
         tags:
-            - { name: ezplatform.admin_ui.user_setting.value, identifier: full_datetime_format }
+            - { name: ezplatform.admin_ui.user_setting.value, identifier: full_datetime_format, priority: 30 }
             - { name: ezplatform.admin_ui.user_setting.form_mapper, identifier: full_datetime_format }
 
     EzSystems\EzPlatformUser\UserSetting\Setting\ShortDateTimeFormat:
         tags:
-            - { name: ezplatform.admin_ui.user_setting.value, identifier: short_datetime_format }
+            - { name: ezplatform.admin_ui.user_setting.value, identifier: short_datetime_format, priority: 40 }
             - { name: ezplatform.admin_ui.user_setting.form_mapper, identifier: short_datetime_format }
 
     EzSystems\EzPlatformUser\UserSetting\Setting\Language:
         arguments:
             $availableLocaleChoiceLoader: '@EzSystems\EzPlatformUser\Form\ChoiceList\Loader\AvailableLocaleChoiceLoader'
         tags:
-            - { name: ezplatform.admin_ui.user_setting.value, identifier: language }
+            - { name: ezplatform.admin_ui.user_setting.value, identifier: language, priority: 60 }
             - { name: ezplatform.admin_ui.user_setting.form_mapper, identifier: language }

--- a/src/lib/UserSetting/ValueDefinitionRegistry.php
+++ b/src/lib/UserSetting/ValueDefinitionRegistry.php
@@ -16,26 +16,31 @@ use EzSystems\EzPlatformAdminUi\UserSetting as AdminUiUserSettings;
  */
 class ValueDefinitionRegistry
 {
-    /** @var \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionInterface[] */
+    /** @var \EzSystems\EzPlatformUser\UserSetting\ValueDefinitionRegistryEntry[] */
     protected $valueDefinitions;
 
     /**
-     * @param \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionInterface[] $valueDefinitions
+     * @param \EzSystems\EzPlatformUser\UserSetting\ValueDefinitionRegistryEntry[] $valueDefinitions
      */
     public function __construct(array $valueDefinitions = [])
     {
-        $this->valueDefinitions = $valueDefinitions;
+        $this->valueDefinitions = [];
+        foreach ($valueDefinitions as $identifier => $valueDefinition) {
+            $valueDefinitions[$identifier] = new ValueDefinitionRegistryEntry($valueDefinition);
+        }
     }
 
     /**
      * @param string $identifier
-     * @param \EzSystems\EzPlatformUser\UserSetting\ValueDefinitionInterface $valueDefinition
+     * @param AdminUiUserSettings\ValueDefinitionInterface $valueDefinition
+     * @param int $priority
      */
     public function addValueDefinition(
         string $identifier,
-        AdminUiUserSettings\ValueDefinitionInterface $valueDefinition
+        AdminUiUserSettings\ValueDefinitionInterface $valueDefinition,
+        int $priority = 0
     ): void {
-        $this->valueDefinitions[$identifier] = $valueDefinition;
+        $this->valueDefinitions[$identifier] = new ValueDefinitionRegistryEntry($valueDefinition, $priority);
     }
 
     /**
@@ -54,7 +59,7 @@ class ValueDefinitionRegistry
             );
         }
 
-        return $this->valueDefinitions[$identifier];
+        return $this->valueDefinitions[$identifier]->getDefinition();
     }
 
     /**
@@ -72,6 +77,12 @@ class ValueDefinitionRegistry
      */
     public function getValueDefinitions(): array
     {
-        return $this->valueDefinitions;
+        uasort($this->valueDefinitions, function (ValueDefinitionRegistryEntry $a, ValueDefinitionRegistryEntry $b) {
+            return $b->getPriority() <=> $a->getPriority();
+        });
+
+        return array_map(function (ValueDefinitionRegistryEntry $entry) {
+            return $entry->getDefinition();
+        }, $this->valueDefinitions);
     }
 }

--- a/src/lib/UserSetting/ValueDefinitionRegistryEntry.php
+++ b/src/lib/UserSetting/ValueDefinitionRegistryEntry.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUser\UserSetting;
+
+/**
+ * @internal
+ */
+final class ValueDefinitionRegistryEntry
+{
+    /** @var \EzSystems\EzPlatformAdminUi\UserSetting\ValueDefinitionInterface */
+    private $definition;
+
+    /** @var int */
+    private $priority;
+
+    /**
+     * @param \EzSystems\EzPlatformUser\UserSetting\ValueDefinitionInterface $definition
+     * @param int $priority
+     */
+    public function __construct(ValueDefinitionInterface $definition, int $priority = 0)
+    {
+        $this->definition = $definition;
+        $this->priority = $priority;
+    }
+
+    /**
+     * @return \EzSystems\EzPlatformUser\UserSetting\ValueDefinitionInterface
+     */
+    public function getDefinition(): ValueDefinitionInterface
+    {
+        return $this->definition;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPriority(): int
+    {
+        return $this->priority;
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [EZP-30253](https://jira.ez.no/browse/EZP-30253)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | -
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Added support for prioritization in the `\EzSystems\EzPlatformUser\UserSetting\ValueDefinitionRegistry` to be able to define proper order of user preferences. 

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review