### PR TITLE
EZP-30251: Display the rendering of time & date when editing the Short/Long Date & Time format

### DIFF
--- a/src/bundle/Controller/UserSettingsController.php
+++ b/src/bundle/Controller/UserSettingsController.php
@@ -96,21 +96,18 @@ class UserSettingsController extends Controller
     }
 
     /**
+     * @param \EzSystems\EzPlatformUser\View\UserSettings\UpdateView $view
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param string $identifier
      *
-     * @return \EzSystems\EzPlatformUser\View\UserSettings\UpdateView|null|\Symfony\Component\HttpFoundation\Response
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
+     * @return \EzSystems\EzPlatformUser\View\UserSettings\UpdateView|\Symfony\Component\HttpFoundation\Response
      */
-    public function updateAction(Request $request, string $identifier)
+    public function updateAction(Request $request, UpdateView $view): UpdateView
     {
-        $userSetting = $this->userSettingService->getUserSetting($identifier);
-        $data = new UserSettingUpdateData($identifier, $userSetting->value);
+        $userSetting = $view->getUserSetting();
 
-        $form = $this->formFactory->updateUserSetting($identifier, $data);
+        $data = new UserSettingUpdateData($userSetting->identifier, $userSetting->value);
+
+        $form = $this->formFactory->updateUserSetting($userSetting->identifier, $data);
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
@@ -134,9 +131,10 @@ class UserSettingsController extends Controller
             }
         }
 
-        return new UpdateView(null, [
+        $view->addParameters([
             'form' => $form->createView(),
-            'user_setting' => $userSetting,
         ]);
+
+        return $view;
     }
 }

--- a/src/bundle/Controller/UserSettingsController.php
+++ b/src/bundle/Controller/UserSettingsController.php
@@ -96,8 +96,8 @@ class UserSettingsController extends Controller
     }
 
     /**
-     * @param \EzSystems\EzPlatformUser\View\UserSettings\UpdateView $view
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param \EzSystems\EzPlatformUser\View\UserSettings\UpdateView $view
      *
      * @return \EzSystems\EzPlatformUser\View\UserSettings\UpdateView|\Symfony\Component\HttpFoundation\Response
      */

--- a/src/bundle/DependencyInjection/Compiler/UserSetting/ViewBuilderRegistryPass.php
+++ b/src/bundle/DependencyInjection/Compiler/UserSetting/ViewBuilderRegistryPass.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUserBundle\DependencyInjection\Compiler\UserSetting;
+
+use EzSystems\EzPlatformUser\View\UserSettings\UpdateViewBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ViewBuilderRegistryPass implements CompilerPassInterface
+{
+    public const VIEW_BUILDER_REGISTRY = 'ezpublish.view_builder.registry';
+    public const VIEW_BUILDER_UPDATE_VIEW = UpdateViewBuilder::class;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition(self::VIEW_BUILDER_REGISTRY)) {
+            return;
+        }
+
+        if (!$container->hasDefinition(self::VIEW_BUILDER_UPDATE_VIEW)) {
+            return;
+        }
+
+        $registry = $container->findDefinition(self::VIEW_BUILDER_REGISTRY);
+        $registry->addMethodCall('addToRegistry', [
+            [$container->getDefinition(self::VIEW_BUILDER_UPDATE_VIEW)],
+        ]);
+    }
+}

--- a/src/bundle/DependencyInjection/Configuration/Parser/UserSettingsUpdateView.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/UserSettingsUpdateView.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\View;
+
+class UserSettingsUpdateView extends View
+{
+    public const NODE_KEY = 'user_settings_update_view';
+    public const INFO = 'Template selection settings when displaying a user setting update form';
+}

--- a/src/bundle/EzPlatformUserBundle.php
+++ b/src/bundle/EzPlatformUserBundle.php
@@ -11,6 +11,7 @@ use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\Chan
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\UserPreferences;
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\UserRegistration;
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\Security;
+use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\UserSettingsUpdateView;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -27,9 +28,11 @@ class EzPlatformUserBundle extends Bundle
         $core->addConfigParser(new ChangePassword());
         $core->addConfigParser(new UserRegistration());
         $core->addConfigParser(new UserPreferences());
+        $core->addConfigParser(new UserSettingsUpdateView());
 
         $container->addCompilerPass(new UserSetting\ValueDefinitionPass());
         $container->addCompilerPass(new UserSetting\FormMapperPass());
+        $container->addCompilerPass(new UserSetting\ViewBuilderRegistryPass());
 
         $core->addDefaultSettings(__DIR__ . '/Resources/config', ['ezplatform_default_settings.yml']);
     }

--- a/src/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yml
@@ -17,6 +17,7 @@ parameters:
     ezsettings.default.user_registration.templates.confirmation: "EzPlatformUserBundle:register:register_confirmation.html.twig"
 
     # User Settings
+    ezsettings.default.user_settings_update_view: {}
     ezsettings.default.user_settings.templates.list: "EzPlatformUserBundle:user_settings:list.html.twig"
     ezsettings.default.user_settings.templates.update: "EzPlatformUserBundle:user_settings:update.html.twig"
 

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -4,8 +4,6 @@ imports:
     - { resource: services/user_settings.yml }
     - { resource: services/forms.yml }
 
-parameters:
-
 services:
     _defaults:
         autowire: true
@@ -31,7 +29,6 @@ services:
             - [setViewTemplate, ['EzSystems\EzPlatformUser\View\ResetPassword\InvalidLinkView', "$user_reset_password.templates.invalid_link$"]]
             - [setViewTemplate, ['EzSystems\EzPlatformUser\View\ResetPassword\SuccessView', "$user_reset_password.templates.success$"]]
             - [setViewTemplate, ['EzSystems\EzPlatformUser\View\UserSettings\ListView', "$user_settings.templates.list$"]]
-            - [setViewTemplate, ['EzSystems\EzPlatformUser\View\UserSettings\UpdateView', "$user_settings.templates.update$"]]
             - [setViewTemplate, ['EzSystems\EzPlatformUser\View\Register\FormView', "$user_registration.templates.form$"]]
             - [setViewTemplate, ['EzSystems\EzPlatformUser\View\Register\ConfirmView', "$user_registration.templates.confirmation$"]]
             - [setPagelayout, ["$pagelayout$"]]

--- a/src/bundle/Resources/config/services/user_settings.yml
+++ b/src/bundle/Resources/config/services/user_settings.yml
@@ -15,6 +15,28 @@ services:
     EzSystems\EzPlatformUser\UserSetting\UserSettingArrayAccessor:
 
     #
+    # User Settings Update Form Views
+    #
+    EzSystems\EzPlatformUser\View\UserSettings\UpdateViewBuilder:
+        arguments:
+            $viewConfigurator: '@ezpublish.view.configurator'
+            $viewParametersInjector: '@ezpublish.view.view_parameters.injector.dispatcher'
+
+    EzSystems\EzPlatformUser\View\UserSettings\UpdateViewProvider:
+        arguments:
+            $matcherFactory: '@ezplatform.user.view.user_setting.update.matcher_factory'
+        tags:
+            - { name: ezpublish.view_provider, type: EzSystems\EzPlatformUser\View\UserSettings\UpdateView, priority: 10 }
+
+    ezplatform.user.view.user_setting.update.matcher_factory:
+        class: '%ezpublish.view.matcher_factory.class%'
+        arguments:
+            $relativeNamespace: 'EzSystems\EzPlatformUser\View\UserSettings\Matcher'
+        calls:
+            - [setContainer, ['@service_container']]
+            - [setMatchConfig, ['$user_settings_update_view$']]
+
+    #
     # User Settings Implementations
     #
     EzSystems\EzPlatformUser\UserSetting\Setting\Timezone:

--- a/src/bundle/Resources/views/user_settings/update.html.twig
+++ b/src/bundle/Resources/views/user_settings/update.html.twig
@@ -14,5 +14,4 @@
     </div>
     {{ form_widget(form.update, {'attr': {'hidden': 'hidden'}}) }}
     {{ form_end(form) }}
-
 {% endblock %}

--- a/src/lib/View/UserSettings/Matcher/Identifier.php
+++ b/src/lib/View/UserSettings/Matcher/Identifier.php
@@ -18,14 +18,14 @@ use EzSystems\EzPlatformUser\View\UserSettings\UpdateView;
 class Identifier implements ViewMatcherInterface
 {
     /** @var string[] */
-    private $identifier = [];
+    private $identifiers = [];
 
     /**
      * {@inheritdoc}
      */
     public function setMatchingConfig($matchingConfig): void
     {
-        $this->identifier = (array)$matchingConfig;
+        $this->identifiers = (array)$matchingConfig;
     }
 
     /**
@@ -37,6 +37,6 @@ class Identifier implements ViewMatcherInterface
             return false;
         }
 
-        return in_array($view->getUserSetting()->identifier, $this->identifier);
+        return in_array($view->getUserSetting()->identifier, $this->identifiers);
     }
 }

--- a/src/lib/View/UserSettings/Matcher/Identifier.php
+++ b/src/lib/View/UserSettings/Matcher/Identifier.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUser\View\UserSettings\Matcher;
+
+use eZ\Publish\Core\MVC\Symfony\Matcher\ViewMatcherInterface;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use EzSystems\EzPlatformUser\View\UserSettings\UpdateView;
+
+/**
+ * Match based on the user setting identifier.
+ */
+class Identifier implements ViewMatcherInterface
+{
+    /** @var string[] */
+    private $identifier = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setMatchingConfig($matchingConfig): void
+    {
+        $this->identifier = (array)$matchingConfig;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function match(View $view): bool
+    {
+        if (!$view instanceof UpdateView || $view->getUserSetting() === null) {
+            return false;
+        }
+
+        return in_array($view->getUserSetting()->identifier, $this->identifier);
+    }
+}

--- a/src/lib/View/UserSettings/UpdateView.php
+++ b/src/lib/View/UserSettings/UpdateView.php
@@ -17,7 +17,7 @@ class UpdateView extends BaseView
     private $userSetting;
 
     /**
-     * @return \EzSystems\EzPlatformUser\UserSetting\UserSetting
+     * @return \EzSystems\EzPlatformUser\UserSetting\UserSetting|null
      */
     public function getUserSetting(): ?UserSetting
     {
@@ -25,7 +25,7 @@ class UpdateView extends BaseView
     }
 
     /**
-     * @param \EzSystems\EzPlatformUser\UserSetting\UserSetting $userSetting|null
+     * @param \EzSystems\EzPlatformUser\UserSetting\UserSetting|null $userSetting
      */
     public function setUserSetting(?UserSetting $userSetting): void
     {

--- a/src/lib/View/UserSettings/UpdateView.php
+++ b/src/lib/View/UserSettings/UpdateView.php
@@ -9,7 +9,36 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformUser\View\UserSettings;
 
 use eZ\Publish\Core\MVC\Symfony\View\BaseView;
+use EzSystems\EzPlatformUser\UserSetting\UserSetting;
 
 class UpdateView extends BaseView
 {
+    /** @var \EzSystems\EzPlatformUser\UserSetting\UserSetting|null */
+    private $userSetting;
+
+    /**
+     * @return \EzSystems\EzPlatformUser\UserSetting\UserSetting
+     */
+    public function getUserSetting(): ?UserSetting
+    {
+        return $this->userSetting;
+    }
+
+    /**
+     * @param \EzSystems\EzPlatformUser\UserSetting\UserSetting $userSetting|null
+     */
+    public function setUserSetting(?UserSetting $userSetting): void
+    {
+        $this->userSetting = $userSetting;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getInternalParameters(): array
+    {
+        return [
+            'user_setting' => $this->getUserSetting(),
+        ];
+    }
 }

--- a/src/lib/View/UserSettings/UpdateViewBuilder.php
+++ b/src/lib/View/UserSettings/UpdateViewBuilder.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUser\View\UserSettings;
+
+use eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilder;
+use eZ\Publish\Core\MVC\Symfony\View\Configurator;
+use eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;
+use EzSystems\EzPlatformUser\UserSetting\UserSettingService;
+
+class UpdateViewBuilder implements ViewBuilder
+{
+    /** @var \EzSystems\EzPlatformUser\UserSetting\UserSettingService */
+    private $userSettingService;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\View\Configurator */
+    private $viewConfigurator;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\View\ParametersInjector */
+    private $viewParametersInjector;
+
+    /**
+     * @param \EzSystems\EzPlatformUser\UserSetting\UserSettingService $userSettingService
+     * @param \eZ\Publish\Core\MVC\Symfony\View\Configurator $viewConfigurator
+     * @param \eZ\Publish\Core\MVC\Symfony\View\ParametersInjector $viewParametersInjector
+     */
+    public function __construct(
+        UserSettingService $userSettingService,
+        Configurator $viewConfigurator,
+        ParametersInjector $viewParametersInjector
+    ) {
+        $this->userSettingService = $userSettingService;
+        $this->viewConfigurator = $viewConfigurator;
+        $this->viewParametersInjector = $viewParametersInjector;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function matches($argument): bool
+    {
+        return 'EzSystems\EzPlatformUserBundle\Controller\UserSettingsController::updateAction' === $argument;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildView(array $parameters): UpdateView
+    {
+        $view = new UpdateView();
+
+        $view->setUserSetting($this->userSettingService->getUserSetting($parameters['identifier']));
+        $this->viewParametersInjector->injectViewParameters($view, $parameters);
+        $this->viewConfigurator->configure($view);
+
+        return $view;
+    }
+}

--- a/src/lib/View/UserSettings/UpdateViewProvider.php
+++ b/src/lib/View/UserSettings/UpdateViewProvider.php
@@ -15,9 +15,7 @@ use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 class UpdateViewProvider implements ViewProvider
 {
-    /**
-     * @var \eZ\Publish\Core\MVC\Symfony\Matcher\MatcherFactoryInterface
-     */
+    /** @var \eZ\Publish\Core\MVC\Symfony\Matcher\MatcherFactoryInterface */
     protected $matcherFactory;
 
     /**
@@ -40,6 +38,13 @@ class UpdateViewProvider implements ViewProvider
         return $this->buildUpdateSettingView($configHash);
     }
 
+    /**
+     * @param array $viewConfig
+     *
+     * @return \EzSystems\EzPlatformUser\View\UserSettings\UpdateView
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
+     */
     protected function buildUpdateSettingView(array $viewConfig): UpdateView
     {
         $view = new UpdateView();

--- a/src/lib/View/UserSettings/UpdateViewProvider.php
+++ b/src/lib/View/UserSettings/UpdateViewProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUser\View\UserSettings;
+
+use eZ\Publish\Core\MVC\Symfony\Matcher\MatcherFactoryInterface;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use eZ\Publish\Core\MVC\Symfony\View\ViewProvider;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+class UpdateViewProvider implements ViewProvider
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Matcher\MatcherFactoryInterface
+     */
+    protected $matcherFactory;
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\Matcher\MatcherFactoryInterface $matcherFactory
+     */
+    public function __construct(MatcherFactoryInterface $matcherFactory)
+    {
+        $this->matcherFactory = $matcherFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getView(View $view)
+    {
+        if (($configHash = $this->matcherFactory->match($view)) === null) {
+            return null;
+        }
+
+        return $this->buildUpdateSettingView($configHash);
+    }
+
+    protected function buildUpdateSettingView(array $viewConfig): UpdateView
+    {
+        $view = new UpdateView();
+
+        if (isset($viewConfig['template'])) {
+            $view->setTemplateIdentifier($viewConfig['template']);
+        }
+
+        if (isset($viewConfig['controller'])) {
+            $view->setControllerReference(new ControllerReference($viewConfig['controller']));
+        }
+
+        if (isset($viewConfig['params']) && is_array($viewConfig['params'])) {
+            $view->addParameters($viewConfig['params']);
+        }
+
+        return $view;
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-30251](https://jira.ez.no/browse/EZP-30251) <!-- URLs to JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Added support for matching user setting update form view based on various criteria. Example configuration:

```yml
ezpublish:
    system:
        admin_group:
            # ...
            user_settings_update_view:
                full:
                    ezplatform_admin_ui_datetime_format:
                        template: '@ezdesign/user/settings/update_datetime_format.html.twig'
                        match:
                            Identifier: [full_datetime_format, short_datetime_format]
                    ezplatform_admin_ui:
                        template: '@ezdesign/user/settings/update.html.twig'
                        match: true
```

Ref. https://github.com/ezsystems/ezplatform-admin-ui/pull/889

#### Checklist:
- [ ] Implement tests
- [X] Coding standards (`$ composer fix-cs`)
