### PR TITLE
EZP-30306: Translation for User Setting Language is missing.

### DIFF
--- a/src/bundle/Resources/translations/user_change_password.en.xliff
+++ b/src/bundle/Resources/translations/user_change_password.en.xliff
@@ -11,16 +11,6 @@
         <target state="new">Your password has been successfully changed.</target>
         <note>key: user.change_password.success</note>
       </trans-unit>
-      <trans-unit id="162598561536040cab3f1048f991da4edf838677" resname="user_change_password.change_password">
-        <source>Change Password</source>
-        <target state="new">Change Password</target>
-        <note>key: user_change_password.change_password</note>
-      </trans-unit>
-      <trans-unit id="e929a5ca0e735e5a1da59d20d7448973af39392d" resname="user_change_password.title">
-        <source>Change my password</source>
-        <target state="new">Change my password</target>
-        <note>key: user_change_password.title</note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/bundle/Resources/translations/user_settings.en.xliff
+++ b/src/bundle/Resources/translations/user_settings.en.xliff
@@ -66,6 +66,16 @@
         <target state="new"><![CDATA[Long Date & Time format]]></target>
         <note>key: settings.full_datetime_format.value.title</note>
       </trans-unit>
+      <trans-unit id="3a4946ea2a7aaa360112cf1e657617e7ce7c7d9b" resname="settings.language.value.description">
+        <source>The language of the administration panel</source>
+        <target state="new">The language of the administration panel</target>
+        <note>key: settings.language.value.description</note>
+      </trans-unit>
+      <trans-unit id="593fb98cf76c44e48e00ce4ee027a6e54b6625fd" resname="settings.language.value.title">
+        <source>Language</source>
+        <target state="new">Language</target>
+        <note>key: settings.language.value.title</note>
+      </trans-unit>
       <trans-unit id="f99a9bb9741db45f57f2436c535d89609ebc6b0d" resname="settings.short_datetime_format.value.description">
         <source><![CDATA[Format for displaying Date & Time]]></source>
         <target state="new"><![CDATA[Format for displaying Date & Time]]></target>

--- a/src/lib/UserSetting/Setting/Language.php
+++ b/src/lib/UserSetting/Setting/Language.php
@@ -25,7 +25,7 @@ class Language implements ValueDefinitionInterface, FormMapperInterface
     /** @var \eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface */
     private $userLanguagePreferenceProvider;
 
-    /** @var \EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\AvailableLocaleChoiceLoader */
+    /** @var \EzSystems\EzPlatformUser\Form\ChoiceList\Loader\AvailableLocaleChoiceLoader */
     private $availableLocaleChoiceLoader;
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-30306](https://jira.ez.no/browse/EZP-30306) <!-- URLs to JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
