### PR TITLE
EZP-30292: Wrong label for displaying Time in User Settings

### DIFF
--- a/src/bundle/Resources/translations/user_settings.en.xliff
+++ b/src/bundle/Resources/translations/user_settings.en.xliff
@@ -12,8 +12,8 @@
         <note>key: ezplatform.date_time_format.date_format.label</note>
       </trans-unit>
       <trans-unit id="5de657d6ce5bc796abc83abde3a6e79503953b17" resname="ezplatform.date_time_format.time_format.label">
-        <source>Format for displaying Date</source>
-        <target state="new">Format for displaying Date</target>
+        <source>Format for displaying Time</source>
+        <target state="new">Format for displaying Time</target>
         <note>key: ezplatform.date_time_format.time_format.label</note>
       </trans-unit>
       <trans-unit id="fb1d64fdeabb5f2fe1671d4f3fb72ccca7722ed3" resname="list.action.edit">

--- a/src/lib/Form/Type/UserSettings/DateTimeFormatType.php
+++ b/src/lib/Form/Type/UserSettings/DateTimeFormatType.php
@@ -28,7 +28,7 @@ class DateTimeFormatType extends AbstractType
         ]);
 
         $builder->add('time_format', ChoiceType::class, [
-            'label' => /** @Desc("Format for displaying Date") */ 'ezplatform.date_time_format.time_format.label',
+            'label' => /** @Desc("Format for displaying Time") */ 'ezplatform.date_time_format.time_format.label',
             'choices' => $options['time_format_choices'],
             'multiple' => false,
             'required' => false,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-30292](https://jira.ez.no/browse/EZP-30292) 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Fixes labels in the DateTimeFormat form 


#### Checklist:
- [ ] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
