### PR TITLE
EZP-30417: Display password reset form validation errors

### DIFF
--- a/src/bundle/Controller/PasswordResetController.php
+++ b/src/bundle/Controller/PasswordResetController.php
@@ -11,6 +11,7 @@ namespace EzSystems\EzPlatformUserBundle\Controller;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\Values\User\User;
+use EzSystems\EzPlatformUser\Form\Data\UserPasswordResetData;
 use EzSystems\EzPlatformUser\Form\Factory\FormFactory;
 use EzSystems\EzPlatformAdminUi\Notification\NotificationHandlerInterface;
 use EzSystems\EzPlatformUser\View\ForgotPassword\FormView;
@@ -172,20 +173,19 @@ class PasswordResetController extends Controller
         $response->headers->set('X-Robots-Tag', 'noindex');
 
         try {
-            $this->userService->loadUserByToken($hashKey);
+            $user = $this->userService->loadUserByToken($hashKey);
         } catch (NotFoundException $e) {
             $view = new InvalidLinkView(null);
             $view->setResponse($response);
 
             return $view;
         }
-
-        $form = $this->formFactory->resetUserPassword();
+        $userPasswordResetData = new UserPasswordResetData(null, $user->getContentType());
+        $form = $this->formFactory->resetUserPassword($userPasswordResetData);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
             try {
-                $user = $this->userService->loadUserByToken($hashKey);
                 $currentUser = $this->permissionResolver->getCurrentUserReference();
                 $this->permissionResolver->setCurrentUserReference($user);
             } catch (NotFoundException $e) {

--- a/src/lib/Form/Data/UserPasswordResetData.php
+++ b/src/lib/Form/Data/UserPasswordResetData.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformUser\Form\Data;
 
 use Symfony\Component\Validator\Constraints as Assert;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 
 class UserPasswordResetData
 {
@@ -18,13 +19,18 @@ class UserPasswordResetData
      * @var string
      */
     private $newPassword;
+    /**
+     * @var \eZ\Publish\API\Repository\Values\ContentType\ContentType
+     */
+    private $contentType;
 
     /**
      * @param string|null $newPassword
      */
-    public function __construct(?string $newPassword = null)
+    public function __construct(?string $newPassword = null, ?ContentType $contentType = null)
     {
         $this->newPassword = $newPassword;
+        $this->contentType = $contentType;
     }
 
     /**
@@ -41,5 +47,21 @@ class UserPasswordResetData
     public function getNewPassword(): ?string
     {
         return $this->newPassword;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\ContentType\ContentType
+     */
+    public function getContentType(): ?ContentType
+    {
+        return $this->contentType;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
+     */
+    public function setContentType(ContentType $contentType): void
+    {
+        $this->contentType = $contentType;
     }
 }

--- a/src/lib/Form/Data/UserPasswordResetData.php
+++ b/src/lib/Form/Data/UserPasswordResetData.php
@@ -19,6 +19,7 @@ class UserPasswordResetData
      * @var string
      */
     private $newPassword;
+
     /**
      * @var \eZ\Publish\API\Repository\Values\ContentType\ContentType
      */

--- a/src/lib/Form/Factory/FormFactory.php
+++ b/src/lib/Form/Factory/FormFactory.php
@@ -75,7 +75,7 @@ class FormFactory
 
     /**
      * @param \EzSystems\EzPlatformUser\Form\Data\UserPasswordForgotWithLoginData $data
-     * @param null|string $name
+     * @param string|null $name
      *
      * @return \Symfony\Component\Form\FormInterface
      *
@@ -92,7 +92,7 @@ class FormFactory
 
     /**
      * @param \EzSystems\EzPlatformUser\Form\Data\UserPasswordResetData $data
-     * @param null|string $name
+     * @param string|null $name
      *
      * @return \Symfony\Component\Form\FormInterface
      *
@@ -104,7 +104,7 @@ class FormFactory
     ): FormInterface {
         $name = $name ?: StringUtil::fqcnToBlockPrefix(UserPasswordResetType::class);
 
-        return $this->formFactory->createNamed($name, UserPasswordResetType::class, $data);
+        return $this->formFactory->createNamed($name, UserPasswordResetType::class, $data, ['content_type' => $data->getContentType()]);
     }
 
     /**

--- a/src/lib/Form/Type/UserPasswordResetType.php
+++ b/src/lib/Form/Type/UserPasswordResetType.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformUser\Form\Type;
 
 use EzSystems\EzPlatformUser\Form\Data\UserPasswordResetData;
+use EzSystems\RepositoryForms\Validator\Constraints\Password;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
@@ -27,6 +28,9 @@ class UserPasswordResetType extends AbstractType
                 'required' => true,
                 'first_options' => ['label' => /** @Desc("New password") */ 'ezplatform.reset_user_password.new_password'],
                 'second_options' => ['label' => /** @Desc("Confirm password") */ 'ezplatform.reset_user_password.confirm_new_password'],
+                'constraints' => [
+                    new Password(['contentType' => $options['content_type']]),
+                ],
             ])
             ->add(
                 'update',
@@ -40,6 +44,7 @@ class UserPasswordResetType extends AbstractType
         $resolver->setDefaults([
             'data_class' => UserPasswordResetData::class,
             'translation_domain' => 'forms',
+            'content_type' => null,
         ]);
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-30417](https://jira.ez.no/browse/EZP-30417) 
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Displayed validation errors for the new password field - implemented ContentType validation checks in the symfony form.
This PR depends on: https://github.com/ezsystems/repository-forms/pull/288

#### Checklist:
- [ ] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
