### PR TITLE
EZP-30514: Moved default configuration to dedicated ViewProvider for the user_settings_update_view

### DIFF
--- a/src/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yml
@@ -18,6 +18,12 @@ parameters:
 
     # User Settings
     ezsettings.default.user_settings_update_view: {}
+    ezsettings.default.user_settings_update_view_defaults:
+        full:
+            default:
+                template: "%ezsettings.default.user_settings.templates.update%"
+                match: []
+
     ezsettings.default.user_settings.templates.list: "EzPlatformUserBundle:user_settings:list.html.twig"
     ezsettings.default.user_settings.templates.update: "EzPlatformUserBundle:user_settings:update.html.twig"
 

--- a/src/bundle/Resources/config/services/user_settings.yml
+++ b/src/bundle/Resources/config/services/user_settings.yml
@@ -28,6 +28,13 @@ services:
         tags:
             - { name: ezpublish.view_provider, type: EzSystems\EzPlatformUser\View\UserSettings\UpdateView, priority: 10 }
 
+    ezplatform.user.view.user_setting.update.default_configured:
+        class: '%ezpublish.view_provider.configured.class%'
+        arguments:
+            $matcherFactory: '@ezplatform.user.view.user_setting.update.default_matcher_factory'
+        tags:
+            - { name: ezpublish.view_provider, type: EzSystems\EzPlatformUser\View\UserSettings\UpdateView, priority: -1 }
+
     ezplatform.user.view.user_setting.update.matcher_factory:
         class: '%ezpublish.view.matcher_factory.class%'
         arguments:
@@ -35,6 +42,14 @@ services:
         calls:
             - [setContainer, ['@service_container']]
             - [setMatchConfig, ['$user_settings_update_view$']]
+
+    ezplatform.user.view.user_setting.update.default_matcher_factory:
+        class: '%ezpublish.view.matcher_factory.class%'
+        arguments:
+            $relativeNamespace: 'EzSystems\EzPlatformUser\View\UserSettings\Matcher'
+        calls:
+            - [setContainer, ['@service_container']]
+            - [setMatchConfig, ['$user_settings_update_view_defaults$']]
 
     #
     # User Settings Implementations


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-30514](https://jira.ez.no/browse/EZP-30514) <!-- URLs to JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

As a developer, I want to be able to define a custom view for the user setting update form without impl. `PrependExtensionInterface`. For example, using the following snippet in the `/app/config/ezplatform.yml`:

```yml
ezpublish:
    system:
        admin_group:
            # ...
            user_settings_update_view:
                full:
                    custom_setting:
                        template: '@ezdesign/user/settings/custom_setting.html.twig'
                        match:
                            Identifier: [ custom_setting ]        
```

Right now is not possible because `ezplatform-admin-ui` is prepending default view 

```yml
ezpublish:
    system:
        admin_group:
                # Default template for update form 
                ezplatform_admin_ui:
                    template: '@ezdesign/user/settings/update.html.twig'
                    match: true
```

which blocks any other configuration added after `ezplatform-admin-ui` .

#### Checklist:
- [ ] Implement tests
- [X] Coding standards (`$ composer fix-cs`)
