### PR TITLE
Fixed multiple issues in user_settings/update.html.twig template

### DIFF
--- a/src/bundle/Resources/views/user_settings/update.html.twig
+++ b/src/bundle/Resources/views/user_settings/update.html.twig
@@ -2,8 +2,7 @@
 
 {% trans_default_domain 'user_settings' %}
 
-{% block form %}
-    {% form_theme form '@ezdesign/form_fields.html.twig' %}
+{% block content %}
     {{ form_start(form) }}
     {{ form_widget(form.identifier, {'attr': {'hidden': 'hidden'}}) }}
     <div class="ez-table-header ground-base">
@@ -12,6 +11,6 @@
     <div class="bg-white p-4">
         {{ form_row(form.value, {'label_attr': {'class': 'ez-label'}}) }}
     </div>
-    {{ form_widget(form.update, {'attr': {'hidden': 'hidden'}}) }}
+    {{ form_widget(form.update) }}
     {{ form_end(form) }}
 {% endblock %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  -
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Fixed multiple issues in the `user_settings/update.html.twig` template which affects  non-admin site accesses:

* Non-existing `form` block in the default page layout template
* Undefined`@ezdesign/form_fields.html.twig` in standard design
* Hidden submit button 

#### Checklist:
- [ ] Implement tests
- [X] Coding standards (`$ composer fix-cs`)
