### PR TITLE
Value definitions passed to the ValueDefinitionRegistry constructor should be available in the registry

### DIFF
--- a/src/lib/UserSetting/ValueDefinitionRegistry.php
+++ b/src/lib/UserSetting/ValueDefinitionRegistry.php
@@ -26,7 +26,7 @@ class ValueDefinitionRegistry
     {
         $this->valueDefinitions = [];
         foreach ($valueDefinitions as $identifier => $valueDefinition) {
-            $valueDefinitions[$identifier] = new ValueDefinitionRegistryEntry($valueDefinition);
+            $this->valueDefinitions[$identifier] = new ValueDefinitionRegistryEntry($valueDefinition);
         }
     }
 

--- a/tests/lib/UserSetting/ValueDefinitionRegistryTest.php
+++ b/tests/lib/UserSetting/ValueDefinitionRegistryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUser\Tests\UserSetting;
+
+use EzSystems\EzPlatformUser\UserSetting\ValueDefinitionRegistry;
+use EzSystems\EzPlatformUser\UserSetting\ValueDefinitionInterface;
+use PHPUnit\Framework\TestCase;
+
+class ValueDefinitionRegistryTest extends TestCase
+{
+    public function testGetValueDefinitions()
+    {
+        $definitions = [
+            'foo' => $this->createMock(ValueDefinitionInterface::class),
+            'bar' => $this->createMock(ValueDefinitionInterface::class),
+            'baz' => $this->createMock(ValueDefinitionInterface::class)
+        ];
+
+        $registry = new ValueDefinitionRegistry($definitions);
+
+        $this->assertEquals($definitions, $registry->getValueDefinitions());
+    }
+
+    public function testAddValueDefinition()
+    {
+        $foo = $this->createMock(ValueDefinitionInterface::class);
+
+        $registry = new ValueDefinitionRegistry([]);
+        $registry->addValueDefinition('foo', $foo);
+
+        $this->assertEquals(['foo' => $foo], $registry->getValueDefinitions());
+    }
+
+    public function testHasValueDefinition()
+    {
+        $registry = new ValueDefinitionRegistry([
+            'foo' => $this->createMock(ValueDefinitionInterface::class),
+        ]);
+
+        $this->assertTrue($registry->hasValueDefinition('foo'));
+        $this->assertFalse($registry->hasValueDefinition('bar'));
+    }
+
+    public function testGetValueDefinition()
+    {
+        $foo = $this->createMock(ValueDefinitionInterface::class);
+
+        $registry = new ValueDefinitionRegistry([
+            'foo' => $foo,
+        ]);
+
+        $this->assertEquals($foo, $registry->getValueDefinition('foo'));
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  -
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

#### Checklist:
- [X] Implement tests
- [X] Coding standards (`$ composer fix-cs`)
