### PR TITLE
EZP-30552: Fixed the User settings pagination

### DIFF
--- a/src/lib/UserSetting/UserSettingService.php
+++ b/src/lib/UserSetting/UserSettingService.php
@@ -88,7 +88,7 @@ class UserSettingService
             $userPreferences[$identifier] = $this->getUserSettingValue($identifier, $userSettingDefinition);
         }
 
-        return $this->createUserSettings($values, $userPreferences);
+        return $this->createUserSettings($slice, $userPreferences);
     }
 
     /**
@@ -96,7 +96,7 @@ class UserSettingService
      */
     public function countUserSettings(): int
     {
-        return $this->userPreferenceService->getUserPreferenceCount();
+        return $this->valueRegistry->countValueDefinitions();
     }
 
     /**

--- a/src/lib/UserSetting/ValueDefinitionRegistry.php
+++ b/src/lib/UserSetting/ValueDefinitionRegistry.php
@@ -85,4 +85,12 @@ class ValueDefinitionRegistry
             return $entry->getDefinition();
         }, $this->valueDefinitions);
     }
+
+    /**
+     * @return int
+     */
+    public function countValueDefinitions(): int
+    {
+        return \count($this->valueDefinitions);
+    }
 }

--- a/tests/lib/UserSetting/UserSettingServiceTest.php
+++ b/tests/lib/UserSetting/UserSettingServiceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUser\Tests\UserSetting;
+
+use eZ\Publish\API\Repository\UserPreferenceService;
+use eZ\Publish\API\Repository\Values\UserPreference\UserPreference;
+use EzSystems\EzPlatformUser\UserSetting\UserSetting;
+use EzSystems\EzPlatformUser\UserSetting\UserSettingService;
+use EzSystems\EzPlatformUser\UserSetting\ValueDefinitionInterface;
+use EzSystems\EzPlatformUser\UserSetting\ValueDefinitionRegistry;
+use PHPUnit\Framework\TestCase;
+
+class UserSettingServiceTest extends TestCase
+{
+    public function testCountUserSettings(): void
+    {
+        $userPreferenceService = $this->createMock(UserPreferenceService::class);
+        $valueRegistry = $this->createMock(ValueDefinitionRegistry::class);
+        $valueRegistry->method('countValueDefinitions')->willReturn(2);
+        $userSettingService = new UserSettingService($userPreferenceService, $valueRegistry);
+
+        $this->assertEquals(2, $userSettingService->countUserSettings());
+    }
+
+    public function testLoadUserSettings(): void
+    {
+        $userPreferenceService = $this->createMock(UserPreferenceService::class);
+        $userPreferenceService->method('getUserPreference')
+            ->willReturnMap([
+                ['identifier_1', new UserPreference(['value' => '1'])],
+                ['identifier_2', new UserPreference(['value' => '2'])],
+                ['identifier_3', new UserPreference(['value' => '3'])],
+                ['identifier_4', new UserPreference(['value' => '4'])],
+            ]
+        );
+
+        $valueRegistry = $this->createMock(ValueDefinitionRegistry::class);
+        $valueRegistry->method('getValueDefinitions')->willReturn([
+            'identifier_1' => $this->getValueDefinition('name_1', 'description_1'),
+            'identifier_2' => $this->getValueDefinition('name_2', 'description_2'),
+            'identifier_3' => $this->getValueDefinition('name_3', 'description_3'),
+            'identifier_4' => $this->getValueDefinition('name_4', 'description_4'),
+        ]);
+        $userSettingService = new UserSettingService($userPreferenceService, $valueRegistry);
+
+        $settings = $userSettingService->loadUserSettings(1, 2);
+        $expected = [
+            new UserSetting([
+                'identifier' => 'identifier_2',
+                'name' => 'name_2',
+                'description' => 'description_2',
+                'value' => '2',
+            ]),
+            new UserSetting([
+                'identifier' => 'identifier_3',
+                'name' => 'name_3',
+                'description' => 'description_3',
+                'value' => '3',
+            ]),
+        ];
+        $this->assertEquals($expected, $settings);
+    }
+
+    /**
+     * @param string $name
+     * @param string $description
+     *
+     * @return \EzSystems\EzPlatformUser\UserSetting\ValueDefinitionInterface
+     */
+    private function getValueDefinition(string $name = 'name', string $description = 'description'): ValueDefinitionInterface
+    {
+        $valueDefinition = $this->createMock(ValueDefinitionInterface::class);
+        $valueDefinition->method('getName')->willReturn($name);
+        $valueDefinition->method('getDescription')->willReturn($description);
+
+        return $valueDefinition;
+    }
+}

--- a/tests/lib/UserSetting/ValueDefinitionRegistryTest.php
+++ b/tests/lib/UserSetting/ValueDefinitionRegistryTest.php
@@ -19,7 +19,7 @@ class ValueDefinitionRegistryTest extends TestCase
         $definitions = [
             'foo' => $this->createMock(ValueDefinitionInterface::class),
             'bar' => $this->createMock(ValueDefinitionInterface::class),
-            'baz' => $this->createMock(ValueDefinitionInterface::class)
+            'baz' => $this->createMock(ValueDefinitionInterface::class),
         ];
 
         $registry = new ValueDefinitionRegistry($definitions);
@@ -56,5 +56,24 @@ class ValueDefinitionRegistryTest extends TestCase
         ]);
 
         $this->assertEquals($foo, $registry->getValueDefinition('foo'));
+    }
+
+    public function testCountValueDefinitions()
+    {
+        $definitions = [
+            'foo' => $this->createMock(ValueDefinitionInterface::class),
+            'bar' => $this->createMock(ValueDefinitionInterface::class),
+        ];
+
+        $registry = new ValueDefinitionRegistry($definitions);
+
+        $this->assertEquals(2, $registry->countValueDefinitions());
+    }
+
+    public function testCountValueDefinitionsWithEmptyRegistry()
+    {
+        $registry = new ValueDefinitionRegistry([]);
+
+        $this->assertEquals(0, $registry->countValueDefinitions());
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-30552](https://jira.ez.no/browse/EZP-30552) <!-- URLs to JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  |no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


User settings returned by loadUserSettings was prepared from all userSettingDefinitions, not sliced ones. Also `countUserSettings()` method was returning a number of setting which was set by the current user, not all available settings.

#### Checklist:
- [x] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
