### PR TITLE
EZP-30553: User settings pagination limit should be different for admin_group and other siteaccesses

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+/**
+ * Configuration parser for pagination limits declaration.
+ *
+ * Example configuration:
+ * ```yaml
+ * ezpublish:
+ *   system:
+ *      default: # configuration per siteaccess or siteaccess group
+ *          pagination:
+ *              user_settings_limit: 10
+ * ```
+ */
+class Pagination extends AbstractParser
+{
+    /**
+     * Adds semantic configuration definition.
+     *
+     * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ezpublish.system.<siteaccess>
+     */
+    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    {
+        $nodeBuilder
+            ->arrayNode('pagination')
+                ->info('System pagination configuration')
+                ->children()
+                    ->scalarNode('user_settings_limit')->isRequired()->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
+    {
+        if (empty($scopeSettings['pagination'])) {
+            return;
+        }
+
+        $settings = $scopeSettings['pagination'];
+        $keys = [
+            'user_settings_limit',
+        ];
+
+        foreach ($keys as $key) {
+            if (!isset($settings[$key]) || empty($settings[$key])) {
+                continue;
+            }
+
+            $contextualizer->setContextualParameter(
+                sprintf('pagination.%s', $key),
+                $currentScope,
+                $settings[$key]
+            );
+        }
+    }
+}

--- a/src/bundle/EzPlatformUserBundle.php
+++ b/src/bundle/EzPlatformUserBundle.php
@@ -8,6 +8,7 @@ namespace EzSystems\EzPlatformUserBundle;
 
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Compiler\UserSetting;
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\ChangePassword;
+use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\Pagination;
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\UserPreferences;
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\UserRegistration;
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\Security;
@@ -26,6 +27,7 @@ class EzPlatformUserBundle extends Bundle
         $core = $container->getExtension('ezpublish');
         $core->addConfigParser(new Security());
         $core->addConfigParser(new ChangePassword());
+        $core->addConfigParser(new Pagination());
         $core->addConfigParser(new UserRegistration());
         $core->addConfigParser(new UserPreferences());
         $core->addConfigParser(new UserSettingsUpdateView());

--- a/src/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yml
@@ -56,3 +56,6 @@ parameters:
 
     # Additional translations e.g. ['en_US', 'nb_NO']
     ezsettings.default.user_preferences.additional_translations: []
+
+    # Pagination limits
+    ezsettings.default.pagination.user_settings_limit: 10


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-30553](https://jira.ez.no/browse/EZP-30553) <!-- URLs to JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    |no
| Tests pass?   | yes
| Doc needed?   |no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->

Related PR: https://github.com/ezsystems/ezplatform-admin-ui/pull/999


#### Checklist:
- [x] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
