### PR TITLE
EZP-30731: Pagination limits are not recognized except for user_settings_limit

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
@@ -10,7 +10,9 @@ namespace EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parse
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition;
 
 /**
  * Configuration parser for pagination limits declaration.
@@ -26,6 +28,8 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  */
 class Pagination extends AbstractParser
 {
+    private const PAGINATION_NODE_KEY = 'pagination';
+
     /**
      * Adds semantic configuration definition.
      *
@@ -33,13 +37,10 @@ class Pagination extends AbstractParser
      */
     public function addSemanticConfig(NodeBuilder $nodeBuilder)
     {
-        $nodeBuilder
-            ->arrayNode('pagination')
-                ->info('System pagination configuration')
-                ->children()
-                    ->scalarNode('user_settings_limit')->isRequired()->end()
-                ->end()
-            ->end();
+        $userSettingsLimitNode = new ScalarNodeDefinition('user_settings_limit');
+
+        $paginationNode = $this->getPaginationNode($nodeBuilder);
+        $paginationNode->append($userSettingsLimitNode);
     }
 
     /**
@@ -67,5 +68,16 @@ class Pagination extends AbstractParser
                 $settings[$key]
             );
         }
+    }
+
+    private function getPaginationNode(NodeBuilder $nodeBuilder): ArrayNodeDefinition
+    {
+        foreach ($nodeBuilder->end()->getChildNodeDefinitions() as $name => $child) {
+            if ($name === self::PAGINATION_NODE_KEY) {
+                return $child;
+            }
+        }
+
+        return $nodeBuilder->arrayNode(self::PAGINATION_NODE_KEY);
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-30731](https://jira.ez.no/browse/EZP-30731) <!-- URLs to JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

In eZ Platform v2.5.2 is not possible to configure pagination for the elements defined in https://github.com/ezsystems/ezplatform-admin-ui/blob/master/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php#L40-L62: the `pagination` node definition has been overwritten by https://github.com/ezsystems/ezplatform-user/blob/master/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php#L36-L42








#### Checklist:
- [ ] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
