### PR TITLE
Installed latest dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /phpunit.xml
 /.php_cs.cache
 composer.lock
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,6 @@
             "EzSystems\\EzPlatformUser\\Tests\\": "tests/lib/"
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "require": {
         "php": "^7.3",
         "ezsystems/ezpublish-kernel": "^8.0@dev",

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,13 @@
         "twig/twig": "^2.11"
     },
     "require-dev": {
+        "ezsystems/ezplatform-admin-ui-modules": "^2.0@dev",
+        "ezsystems/ezplatform-content-forms": "^1.0@dev", 
+        "ezsystems/ezplatform-richtext": "^2.0@dev",
+        "ezsystems/ezplatform-rest": "^1.0@dev",
+        "ezsystems/doctrine-dbal-schema": "^1.0@dev",
+        "ezsystems/ez-support-tools": "^2.0@dev",
+        "ezsystems/ezplatform-design-engine": "^3.0@dev",
         "friendsofphp/php-cs-fixer": "^2.16.0",
         "ezsystems/ezplatform-code-style": "^0.1.0",
         "phpunit/phpunit": "^8.2"


### PR DESCRIPTION
Instead of latest kernel the `8.0.0-beta4` version is downloaded (because prefer-stable is set to true).

Changing it so that the master from kernel is downloaded.