### PR TITLE
Added Travis config, upgrade php-cs-fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -13,10 +13,13 @@ return PhpCsFixer\Config::create()
         'array_syntax' => ['syntax' => 'short'],
         'simplified_null_return' => false,
         'phpdoc_align' => false,
+        'phpdoc_separation' => false,
         'phpdoc_to_comment' => false,
         'cast_spaces' => false,
         'blank_line_after_opening_tag' => false,
         'single_blank_line_before_namespace' => false,
+        'phpdoc_annotation_without_dot' => false,
+        'phpdoc_no_alias_tag' => false,
         'space_after_semicolon' => false,
         'header_comment' => [
             'commentType' => 'PHPDoc',
@@ -26,6 +29,14 @@ return PhpCsFixer\Config::create()
         ],
         'yoda_style' => false,
         'no_break_comment' => false,
+        'native_function_invocation' => false,
+        'native_constant_invocation' => false,
+        'phpdoc_types_order' => false,
+        'php_unit_mock_short_will_return' => false,
+        'php_unit_construct' => false,
+        'standardize_increment' => false,
+        'fopen_flags' => false,
+        'self_accessor' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+dist: trusty
+sudo: required
+
+language: php
+
+cache:
+  directories:
+  - "$HOME/.composer/cache/files"
+
+matrix:
+  fast_finish: true
+  include:
+  - name: PHP 7.3 Unit tests
+    php: 7.3
+    env: TEST_CONFIG="phpunit.xml"
+  - name: Code Style Check
+    php: 7.3
+    env: CHECK_CS=1
+
+branches:
+  only:
+  - master
+  - /^\d.\d+$/
+
+before_install:
+- echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+- TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
+- TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}
+
+install:
+- travis_retry composer install --prefer-dist --no-interaction --no-suggest
+
+script:
+- if [ "$TEST_CONFIG" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1
+  vendor/bin/phpunit -c $TEST_CONFIG ; fi
+- if [ "$CHECK_CS" == "1" ] ; then ./vendor/bin/php-cs-fixer fix -v --dry-run --show-progress=estimating; fi
+
+notifications:
+  slack:
+    rooms:
+      - secure: WHaF3LihH1WgOrdo7XCVooAjCED48eBo5T7wuDLIHxZzEHZnRx+cwUe0ta4/m/hjAl1kXmfay0nwCnvjEPCOGN45SnA5yAOVsR0ExFr9QYCUlh967a5a6ckagdO6S8alqFmVaUhhTrfLOO4yorr7cdHr0n3l0U/vm4QA3+40vPsZH4C7+Z80i9EFt2IPGzwDamVIXGaBS5AkJyYYT9PAwv2XYdUJDy+jWP0a1w2PbCWGzGLnIYJ472kzzUfPMoTmNpqRkvTyoNToJ+mfW24FssjB05eLwbcy8FDBYH+BrM88uKG6TgAyAOfUuA/EzMooe5cQs3faneExFxxt3aLwRde3OLJJtNUFCNwRUqD3IXQCDZVlqUfkuo0/2NTjeDAb08qNOyi0/dCBLYedeOEfYqGhhc7WYITKHTtXKCQMI4GbMxWVDMSo9wpXgoaCwCVP5LBbiHrwe5Vr4NzQmOwwcIC4IGVW2z2GT1JQ5uahMJ1klITlxn+rCBdE8dde6OFVNiS7UUnI7r6hMHoaUlWV8n1pb8cYH9ZubEUjZzZ5RFu8cFX/Q52Rk3n5AYSWIqcMF94sGj1TsHw2b+ex+GWYMVhXQ1hvx2YwF5PtMY9oKuzcwntAKYvNWMIdBU8M4UFdLxChSBwcNhJPQ9435qlgNkee/836d1FuL42LCyfvi8I=
+    on_success: change
+    on_failure: always
+    on_pull_requests: false
+
+git:
+  depth: 30

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",
-        "friendsofphp/php-cs-fixer": "~2.7.1"
+        "friendsofphp/php-cs-fixer": "~2.15.0"
     },
     "scripts": {
         "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-30872
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This PR:
1) adds Travis config
2) bumps php-cs-fixer to ~2.15.0, the same version we use in Kernel
3) "borrows" missing configuration for CS-fixer from https://github.com/ezsystems/ezpublish-kernel/blob/7.5/.php_cs
