### PR TITLE
EZP-30965: Fixed wrong argument passed to MenuManipulator::moveToPosition() method

### DIFF
--- a/src/lib/EventListener/UserMenuListener.php
+++ b/src/lib/EventListener/UserMenuListener.php
@@ -54,10 +54,10 @@ class UserMenuListener implements EventSubscriberInterface, TranslationContainer
                     'extras' => ['translation_domain' => 'menu'],
                 ]
             );
-        }
 
-        $manipulator = new MenuManipulator();
-        $manipulator->moveToPosition($menu[self::ITEM_CHANGE_PASSWORD], 0);
+            $manipulator = new MenuManipulator();
+            $manipulator->moveToPosition($menu[self::ITEM_CHANGE_PASSWORD], 0);
+        }
     }
 
     /**

--- a/tests/lib/EventListener/UserMenuListenerTest.php
+++ b/tests/lib/EventListener/UserMenuListenerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent;
+use EzSystems\EzPlatformUser\EventListener\UserMenuListener;
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * @author Hannes Giesenow <hannes.giesenow@elbformat.de>
+ */
+final class UserMenuListenerTest extends TestCase
+{
+
+    public function testOnUserMenuConfigureAnonUser(): void
+    {
+        $factory = $this->getMockBuilder(FactoryInterface::class)->getMock();
+        $menu = $this->getMockBuilder(ItemInterface::class)->getMock();
+        $menu->expects($this->never())->method('reorderChildren');
+        $event = new ConfigureMenuEvent($factory, $menu);
+        $tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)->disableOriginalConstructor()->getMock();
+        $listener = new UserMenuListener($tokenStorage);
+        $listener->onUserMenuConfigure($event);
+    }
+
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-30965](https://jira.ez.no/browse/EZP-30965)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)


#### Checklist:
- [x] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
