### PR TITLE
EZP-31195: Set From to swiftmailer when From in twig is empty. Set Fr…

### DIFF
--- a/src/bundle/Controller/PasswordResetController.php
+++ b/src/bundle/Controller/PasswordResetController.php
@@ -56,6 +56,9 @@ class PasswordResetController extends Controller
     /** @var string */
     private $forgotPasswordMail;
 
+    /** @var string */
+    private $senderAddress;
+
     /**
      * @param \EzSystems\EzPlatformUser\Form\Factory\FormFactory $formFactory
      * @param \eZ\Publish\API\Repository\UserService $userService
@@ -65,6 +68,7 @@ class PasswordResetController extends Controller
      * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
      * @param string $tokenIntervalSpec
      * @param string $forgotPasswordMail
+     * @param string $senderAddress
      */
     public function __construct(
         FormFactory $formFactory,
@@ -74,7 +78,8 @@ class PasswordResetController extends Controller
         NotificationHandlerInterface $notificationHandler,
         PermissionResolver $permissionResolver,
         string $tokenIntervalSpec,
-        string $forgotPasswordMail
+        string $forgotPasswordMail,
+        string $senderAddress
     ) {
         $this->formFactory = $formFactory;
         $this->userService = $userService;
@@ -84,6 +89,7 @@ class PasswordResetController extends Controller
         $this->permissionResolver = $permissionResolver;
         $this->tokenIntervalSpec = $tokenIntervalSpec;
         $this->forgotPasswordMail = $forgotPasswordMail;
+        $this->senderAddress = $senderAddress;
     }
 
     /**
@@ -251,6 +257,10 @@ class PasswordResetController extends Controller
         $subject = $template->renderBlock('subject', []);
         $from = $template->renderBlock('from', []);
         $body = $template->renderBlock('body', ['hashKey' => $hashKey]);
+
+        if (empty($from)) {
+            $from = $this->senderAddress;
+        }
 
         $message = (new Swift_Message())
             ->setSubject($subject)

--- a/src/bundle/Controller/PasswordResetController.php
+++ b/src/bundle/Controller/PasswordResetController.php
@@ -79,7 +79,7 @@ class PasswordResetController extends Controller
         PermissionResolver $permissionResolver,
         string $tokenIntervalSpec,
         string $forgotPasswordMail,
-        string $senderAddress
+        string $senderAddress = ''
     ) {
         $this->formFactory = $formFactory;
         $this->userService = $userService;

--- a/src/bundle/Controller/PasswordResetController.php
+++ b/src/bundle/Controller/PasswordResetController.php
@@ -255,18 +255,17 @@ class PasswordResetController extends Controller
         $template = $this->twig->loadTemplate($this->forgotPasswordMail);
 
         $subject = $template->renderBlock('subject', []);
-        $from = $template->renderBlock('from', []);
+        $from = $template->renderBlock('from', []) ?: $this->senderAddress;
         $body = $template->renderBlock('body', ['hashKey' => $hashKey]);
-
-        if (empty($from)) {
-            $from = $this->senderAddress;
-        }
 
         $message = (new Swift_Message())
             ->setSubject($subject)
-            ->setFrom($from)
             ->setTo($to)
             ->setBody($body, 'text/html');
+
+        if (empty($from) === false) {
+            $message->setFrom($from);
+        }
 
         $this->mailer->send($message);
     }

--- a/src/bundle/Resources/config/services/controllers.yml
+++ b/src/bundle/Resources/config/services/controllers.yml
@@ -19,6 +19,7 @@ services:
         arguments:
             $tokenIntervalSpec: '$security.token_interval_spec$'
             $forgotPasswordMail: '$user_forgot_password.templates.mail$'
+            $senderAddress: '%swiftmailer.sender_address%'
 
     EzSystems\EzPlatformUserBundle\Controller\PasswordChangeController:
         autowire: true

--- a/src/bundle/Resources/config/services/controllers.yml
+++ b/src/bundle/Resources/config/services/controllers.yml
@@ -19,7 +19,7 @@ services:
         arguments:
             $tokenIntervalSpec: '$security.token_interval_spec$'
             $forgotPasswordMail: '$user_forgot_password.templates.mail$'
-            $senderAddress: '%swiftmailer.sender_address%'
+            $senderAddress: "@=container.hasParameter('swiftmailer.sender_address') ? parameter('swiftmailer.sender_address') : ''"
 
     EzSystems\EzPlatformUserBundle\Controller\PasswordChangeController:
         autowire: true

--- a/src/bundle/Resources/views/Security/mail/forgot_user_password.html.twig
+++ b/src/bundle/Resources/views/Security/mail/forgot_user_password.html.twig
@@ -1,5 +1,4 @@
 {%- block from -%}
-    noreply@domain.com
 {%- endblock from -%}
 
 {%- block subject -%}

--- a/src/bundle/Resources/views/forgot_password/mail/forgot_user_password.html.twig
+++ b/src/bundle/Resources/views/forgot_password/mail/forgot_user_password.html.twig
@@ -1,7 +1,6 @@
 {% trans_default_domain 'forgot_password' %}
 
 {%- block from -%}
-    noreply@domain.com
 {%- endblock from -%}
 
 {%- block subject -%}


### PR DESCRIPTION
 Question      | Answer
| ------------- | ---
| Tickets       | [EZP-31195](https://jira.ez.no/browse/EZP-31195)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

if FROM is not set in twig then FROM is taken from the sender_address parameter.
Removed default mail from twig

Another PR's to this ticket
https://github.com/ezsystems/ezplatform-form-builder/pull/210
https://github.com/ezsystems/ezplatform-admin-ui/pull/1240

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
- [x] Ready for Code Review