### PR TITLE
EZP-31496: Fixed removed getLocaleBundle() method from Intl Component

### DIFF
--- a/src/lib/Form/ChoiceList/Loader/AvailableLocaleChoiceLoader.php
+++ b/src/lib/Form/ChoiceList/Loader/AvailableLocaleChoiceLoader.php
@@ -10,9 +10,9 @@ namespace EzSystems\EzPlatformUser\Form\ChoiceList\Loader;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use EzSystems\EzPlatformAdminUi\Form\Type\ChoiceList\Loader\BaseChoiceLoader;
+use Symfony\Component\Intl\Locales;
 use Symfony\Component\Validator\Constraints\Locale;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Symfony\Component\Intl\Intl;
 
 class AvailableLocaleChoiceLoader extends BaseChoiceLoader
 {
@@ -52,7 +52,7 @@ class AvailableLocaleChoiceLoader extends BaseChoiceLoader
 
         foreach ($availableLocales as $locale) {
             if (0 === $this->validator->validate($locale, new Locale())->count()) {
-                $choices[Intl::getLocaleBundle()->getLocaleName($locale)] = $locale;
+                $choices[Locales::getName($locale)] = $locale;
             }
         }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-31496](https://jira.ez.no/browse/EZP-31496) <!-- URLs to JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
