### PR TITLE
EZP-31007: Replaced ezpublish-kernel with ezplatform-kernel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": "^7.3",
-        "ezsystems/ezpublish-kernel": "^8.0@dev",
+        "ezsystems/ezplatform-kernel": "^1.0@dev",
         "ezsystems/ezplatform-admin-ui": "^2.0@dev",
         "jms/translation-bundle": "^1.5",
         "symfony/dependency-injection": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,13 @@
         "twig/twig": "^3.0"
     },
     "require-dev": {
+        "ezsystems/doctrine-dbal-schema": "^1.0@dev",
+        "ezsystems/ez-support-tools": "^2.0@dev",
+        "ezsystems/ezplatform-admin-ui-modules": "^2.0@dev",
+        "ezsystems/ezplatform-content-forms": "^1.0@dev",
+        "ezsystems/ezplatform-design-engine": "^3.0@dev",
+        "ezsystems/ezplatform-richtext": "^2.0@dev",
+        "ezsystems/ezplatform-rest": "^1.0@dev",
         "friendsofphp/php-cs-fixer": "^2.16.0",
         "ezsystems/ezplatform-code-style": "^0.1.0",
         "phpunit/phpunit": "^8.2"


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31007](https://jira.ez.no/browse/EZP-31007)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

This PR replaces `ezpublish-kernel` with `ezplatform-kernel` and fixes dependency issues blocking package installation (due to Composer minimum stability requirements):

- `ezsystems/doctrine-dbal-schema:^1.0@dev` is required  by `ezplatform-kernel:^1.0@dev`
- other packages are required by `ezsystems/ezplatform-admin-ui:^2.0@dev`

#### TODO
- [x] Wait for Travis