### PR TITLE
EZP-31536: Fixed invalid \Twig\Environment::loadTemplate method call

### DIFF
--- a/src/bundle/Controller/PasswordResetController.php
+++ b/src/bundle/Controller/PasswordResetController.php
@@ -240,13 +240,9 @@ class PasswordResetController extends Controller
         return $struct->hashKey;
     }
 
-    /**
-     * @param string $to
-     * @param string $hashKey
-     */
     private function sendResetPasswordMessage(string $to, string $hashKey): void
     {
-        $template = $this->twig->loadTemplate($this->forgotPasswordMail);
+        $template = $this->twig->load($this->forgotPasswordMail);
 
         $subject = $template->renderBlock('subject', []);
         $from = $template->renderBlock('from', []);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-31536](https://jira.ez.no/browse/EZP-31536) <!-- URLs to JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | ?
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Fixed 

```
Too few arguments to function Twig\Environment::loadTemplate(), 1 passed in /home/vagrant/master/vendor/ezsystems/ezplatform-user/src/bundle/Controller/PasswordResetController.php on line 249 and at least 2 expected
```

by replacing `\Twig\Environment::loadTemplate` by `\Twig\Environment::load`


#### Checklist:
- [X] Implement tests
- [X] Coding standards (`$ composer fix-cs`)
