### PR TITLE
EZP-31017: Added Password Validator to change password form

### DIFF
--- a/src/bundle/Controller/PasswordChangeController.php
+++ b/src/bundle/Controller/PasswordChangeController.php
@@ -66,7 +66,9 @@ class PasswordChangeController extends Controller
      */
     public function userPasswordChangeAction(Request $request)
     {
-        $form = $this->formFactory->changeUserPassword();
+        /** @var \eZ\Publish\API\Repository\Values\User\User $user */
+        $user = $this->tokenStorage->getToken()->getUser()->getAPIUser();
+        $form = $this->formFactory->changeUserPassword($user->getContentType());
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -76,7 +78,6 @@ class PasswordChangeController extends Controller
                 $newPassword = $data->getNewPassword();
                 $userUpdateStruct = $this->userService->newUserUpdateStruct();
                 $userUpdateStruct->password = $newPassword;
-                $user = $this->tokenStorage->getToken()->getUser()->getAPIUser();
                 $this->userService->updateUser($user, $userUpdateStruct);
 
                 if ((new IsAdmin($this->siteAccessGroups))->isSatisfiedBy($request->attributes->get('siteaccess'))) {

--- a/src/bundle/Controller/PasswordResetController.php
+++ b/src/bundle/Controller/PasswordResetController.php
@@ -166,8 +166,8 @@ class PasswordResetController extends Controller
 
             return $view;
         }
-        $userPasswordResetData = new UserPasswordResetData(null, $user->getContentType());
-        $form = $this->formFactory->resetUserPassword($userPasswordResetData);
+        $userPasswordResetData = new UserPasswordResetData();
+        $form = $this->formFactory->resetUserPassword($userPasswordResetData, null, $user->getContentType());
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/bundle/Resources/config/routing.yaml
+++ b/src/bundle/Resources/config/routing.yaml
@@ -22,18 +22,6 @@ ezplatform.user.reset_password:
     defaults:
         _controller: 'EzSystems\EzPlatformUserBundle\Controller\PasswordResetController::userResetPasswordAction'
 
-# Deprecated in v2.5 and will be removed in v3.0. Use ezplatform.user.register instead.
-ez_user_register:
-    path: /register
-    defaults:
-        _controller: 'EzSystems\EzPlatformUserBundle\Controller\UserRegisterController::registerAction'
-
-# Deprecated in v2.5 and will be removed in v3.0. Use ezplatform.user.register_confirmation instead.
-ez_user_register_confirmation:
-    path: /register-confirm
-    defaults:
-        _controller: 'EzSystems\EzPlatformUserBundle\Controller\UserRegisterController::registerConfirmAction'
-
 ezplatform.user.register: &user_register
     path: /register
     defaults:

--- a/src/bundle/Resources/config/services/validators.yaml
+++ b/src/bundle/Resources/config/services/validators.yaml
@@ -10,3 +10,9 @@ services:
     EzSystems\EzPlatformUser\Validator\Constraints\UserPasswordValidator:
         tags:
             - { name: validator.constraint_validator }
+
+    EzSystems\EzPlatformUser\Validator\Constraints\PasswordValidator:
+        arguments:
+            $userService: '@ezpublish.api.service.user'
+        tags:
+            - { name: validator.constraint_validator }

--- a/src/lib/Form/Data/UserPasswordResetData.php
+++ b/src/lib/Form/Data/UserPasswordResetData.php
@@ -21,7 +21,8 @@ class UserPasswordResetData
     private $newPassword;
 
     /**
-     * @deprecated ContentType should be passed as option to FormType
+     * @deprecated ContentType should be passed as option to FormType.
+     *
      * @var \eZ\Publish\API\Repository\Values\ContentType\ContentType
      */
     private $contentType;

--- a/src/lib/Form/Data/UserPasswordResetData.php
+++ b/src/lib/Form/Data/UserPasswordResetData.php
@@ -21,6 +21,7 @@ class UserPasswordResetData
     private $newPassword;
 
     /**
+     * @deprecated ContentType should be passed as option to FormType
      * @var \eZ\Publish\API\Repository\Values\ContentType\ContentType
      */
     private $contentType;

--- a/src/lib/Form/Data/UserRegisterData.php
+++ b/src/lib/Form/Data/UserRegisterData.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformUser\Form\Data;
 
-use EzSystems\EzPlatformContentForms\Data as RepositoryFormsData;
+use EzSystems\EzPlatformContentForms\Data\User\UserCreateData;
 
-class UserRegisterData extends RepositoryFormsData\User\UserRegisterData
+class UserRegisterData extends UserCreateData
 {
 }

--- a/src/lib/Form/Factory/FormFactory.php
+++ b/src/lib/Form/Factory/FormFactory.php
@@ -53,7 +53,7 @@ class FormFactory
             $name,
             UserPasswordChangeType::class,
             $data,
-            ['userContentType' => $contentType]
+            ['content_type' => $contentType]
         );
     }
 
@@ -101,11 +101,13 @@ class FormFactory
      */
     public function resetUserPassword(
         UserPasswordResetData $data = null,
-        ?string $name = null
+        ?string $name = null,
+        ContentType $contentType = null
     ): FormInterface {
         $name = $name ?: StringUtil::fqcnToBlockPrefix(UserPasswordResetType::class);
 
-        return $this->formFactory->createNamed($name, UserPasswordResetType::class, $data, ['content_type' => $data->getContentType()]);
+        $userContentType = $contentType ?? $data->getContentType();
+        return $this->formFactory->createNamed($name, UserPasswordResetType::class, $data, ['content_type' => $userContentType]);
     }
 
     /**

--- a/src/lib/Form/Factory/FormFactory.php
+++ b/src/lib/Form/Factory/FormFactory.php
@@ -107,6 +107,7 @@ class FormFactory
         $name = $name ?: StringUtil::fqcnToBlockPrefix(UserPasswordResetType::class);
 
         $userContentType = $contentType ?? $data->getContentType();
+
         return $this->formFactory->createNamed($name, UserPasswordResetType::class, $data, ['content_type' => $userContentType]);
     }
 

--- a/src/lib/Form/Factory/FormFactory.php
+++ b/src/lib/Form/Factory/FormFactory.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformUser\Form\Factory;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use EzSystems\EzPlatformUser\Form\Data\UserPasswordForgotData;
 use EzSystems\EzPlatformUser\Form\Data\UserPasswordChangeData;
 use EzSystems\EzPlatformUser\Form\Data\UserSettingUpdateData;
@@ -41,19 +42,19 @@ class FormFactory
         $this->urlGenerator = $urlGenerator;
     }
 
-    /**
-     * @param \EzSystems\EzPlatformUser\Form\Data\UserPasswordChangeData|null $data
-     * @param string|null $name
-     *
-     * @return \Symfony\Component\Form\FormInterface
-     */
     public function changeUserPassword(
+        ContentType $contentType,
         UserPasswordChangeData $data = null,
         ?string $name = null
     ): FormInterface {
         $name = $name ?: StringUtil::fqcnToBlockPrefix(UserPasswordChangeType::class);
 
-        return $this->formFactory->createNamed($name, UserPasswordChangeType::class, $data);
+        return $this->formFactory->createNamed(
+            $name,
+            UserPasswordChangeType::class,
+            $data,
+            ['userContentType' => $contentType]
+        );
     }
 
     /**

--- a/src/lib/Form/Type/UserPasswordChangeType.php
+++ b/src/lib/Form/Type/UserPasswordChangeType.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformUser\Form\Type;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use EzSystems\EzPlatformAdminUi\Validator\Constraints\Password;
 use EzSystems\EzPlatformUser\Form\Data\UserPasswordChangeData;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
@@ -31,6 +33,11 @@ class UserPasswordChangeType extends AbstractType
                 'required' => true,
                 'first_options' => ['label' => /** @Desc("New password") */ 'ezplatform.change_user_password.new_password'],
                 'second_options' => ['label' => /** @Desc("Confirm password") */ 'ezplatform.change_user_password.confirm_new_password'],
+                'constraints' => [
+                    new Password([
+                        'contentType' => $options['userContentType'],
+                    ]),
+                ],
             ])
             ->add(
                 'change',
@@ -41,6 +48,10 @@ class UserPasswordChangeType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver)
     {
+        $resolver->setRequired(
+            'userContentType'
+        );
+        $resolver->setAllowedTypes('userContentType', ContentType::class);
         $resolver->setDefaults([
             'data_class' => UserPasswordChangeData::class,
             'translation_domain' => 'forms',

--- a/src/lib/Form/Type/UserPasswordChangeType.php
+++ b/src/lib/Form/Type/UserPasswordChangeType.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformUser\Form\Type;
 
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
-use EzSystems\EzPlatformAdminUi\Validator\Constraints\Password;
 use EzSystems\EzPlatformUser\Form\Data\UserPasswordChangeData;
+use EzSystems\EzPlatformUser\Validator\Constraints\Password;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
@@ -35,7 +35,7 @@ class UserPasswordChangeType extends AbstractType
                 'second_options' => ['label' => /** @Desc("Confirm password") */ 'ezplatform.change_user_password.confirm_new_password'],
                 'constraints' => [
                     new Password([
-                        'contentType' => $options['userContentType'],
+                        'contentType' => $options['content_type'],
                     ]),
                 ],
             ])
@@ -48,10 +48,8 @@ class UserPasswordChangeType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setRequired(
-            'userContentType'
-        );
-        $resolver->setAllowedTypes('userContentType', ContentType::class);
+        $resolver->setRequired('content_type');
+        $resolver->setAllowedTypes('content_type', ContentType::class);
         $resolver->setDefaults([
             'data_class' => UserPasswordChangeData::class,
             'translation_domain' => 'forms',

--- a/src/lib/Form/Type/UserPasswordResetType.php
+++ b/src/lib/Form/Type/UserPasswordResetType.php
@@ -8,8 +8,9 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformUser\Form\Type;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use EzSystems\EzPlatformUser\Form\Data\UserPasswordResetData;
-use EzSystems\EzPlatformContentForms\Validator\Constraints\Password;
+use EzSystems\EzPlatformUser\Validator\Constraints\Password;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
@@ -41,10 +42,11 @@ class UserPasswordResetType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver)
     {
+        $resolver->setRequired('content_type');
+        $resolver->setAllowedTypes('content_type', ContentType::class);
         $resolver->setDefaults([
             'data_class' => UserPasswordResetData::class,
             'translation_domain' => 'forms',
-            'content_type' => null,
         ]);
     }
 }

--- a/src/lib/Validator/Constraints/Password.php
+++ b/src/lib/Validator/Constraints/Password.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUser\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class Password extends Constraint
+{
+    /** @var string */
+    public $message = 'ez.user.password.invalid';
+
+    /** @var \eZ\Publish\API\Repository\Values\ContentType\ContentType|null */
+    public $contentType;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets(): array
+    {
+        return [self::CLASS_CONSTRAINT, self::PROPERTY_CONSTRAINT];
+    }
+}

--- a/src/lib/Validator/Constraints/PasswordValidator.php
+++ b/src/lib/Validator/Constraints/PasswordValidator.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUser\Validator\Constraints;
+
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\API\Repository\Values\User\PasswordValidationContext;
+use EzSystems\EzPlatformContentForms\Validator\ValidationErrorsProcessor;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class PasswordValidator extends ConstraintValidator
+{
+    /** @var \eZ\Publish\API\Repository\UserService */
+    private $userService;
+
+    public function __construct(UserService $userService)
+    {
+        $this->userService = $userService;
+    }
+
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!\is_string($value) || empty($value)) {
+            return;
+        }
+
+        $passwordValidationContext = new PasswordValidationContext([
+            'contentType' => $constraint->contentType,
+        ]);
+
+        $validationErrors = $this->userService->validatePassword($value, $passwordValidationContext);
+        if (!empty($validationErrors)) {
+            $validationErrorsProcessor = $this->createValidationErrorsProcessor();
+            $validationErrorsProcessor->processValidationErrors($validationErrors);
+        }
+    }
+
+    protected function createValidationErrorsProcessor(): ValidationErrorsProcessor
+    {
+        return new ValidationErrorsProcessor($this->context);
+    }
+}

--- a/tests/lib/Validator/Constraint/PasswordTest.php
+++ b/tests/lib/Validator/Constraint/PasswordTest.php
@@ -23,17 +23,17 @@ class PasswordTest extends TestCase
         $this->constraint = new Password();
     }
 
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $this->assertSame('ez.user.password.invalid', $this->constraint->message);
     }
 
-    public function testValidatedBy()
+    public function testValidatedBy(): void
     {
         $this->assertSame(PasswordValidator::class, $this->constraint->validatedBy());
     }
 
-    public function testGetTargets()
+    public function testGetTargets(): void
     {
         $this->assertSame([Password::CLASS_CONSTRAINT, Password::PROPERTY_CONSTRAINT], $this->constraint->getTargets());
     }

--- a/tests/lib/Validator/Constraint/PasswordTest.php
+++ b/tests/lib/Validator/Constraint/PasswordTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUser\Tests\Validator\Constraint;
+
+
+use EzSystems\EzPlatformUser\Validator\Constraints\Password;
+use EzSystems\EzPlatformUser\Validator\Constraints\PasswordValidator;
+use PHPUnit\Framework\TestCase;
+
+class PasswordTest extends TestCase
+{
+    /** @var \EzSystems\EzPlatformUser\Validator\Constraints\Password */
+    private $constraint;
+
+    protected function setUp(): void
+    {
+        $this->constraint = new Password();
+    }
+
+    public function testConstruct()
+    {
+        $this->assertSame('ez.user.password.invalid', $this->constraint->message);
+    }
+
+    public function testValidatedBy()
+    {
+        $this->assertSame(PasswordValidator::class, $this->constraint->validatedBy());
+    }
+
+    public function testGetTargets()
+    {
+        $this->assertSame([Password::CLASS_CONSTRAINT, Password::PROPERTY_CONSTRAINT], $this->constraint->getTargets());
+    }
+}

--- a/tests/lib/Validator/Constraint/PasswordTest.php
+++ b/tests/lib/Validator/Constraint/PasswordTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformUser\Tests\Validator\Constraint;
 
-
 use EzSystems\EzPlatformUser\Validator\Constraints\Password;
 use EzSystems\EzPlatformUser\Validator\Constraints\PasswordValidator;
 use PHPUnit\Framework\TestCase;

--- a/tests/lib/Validator/Constraint/PasswordValidatorTest.php
+++ b/tests/lib/Validator/Constraint/PasswordValidatorTest.php
@@ -40,7 +40,7 @@ class PasswordValidatorTest extends TestCase
     /**
      * @dataProvider dataProviderForValidateNotSupportedValueType
      */
-    public function testValidateShouldBeSkipped($value)
+    public function testValidateShouldBeSkipped($value): void
     {
         $this->userService
             ->expects($this->never())
@@ -53,7 +53,7 @@ class PasswordValidatorTest extends TestCase
         $this->validator->validate($value, new Password());
     }
 
-    public function testValid()
+    public function testValid(): void
     {
         $password = 'pass';
         $contentType = $this->createMock(ContentType::class);
@@ -61,7 +61,10 @@ class PasswordValidatorTest extends TestCase
         $this->userService
             ->expects($this->once())
             ->method('validatePassword')
-            ->willReturnCallback(function ($actualPassword, $actualContext) use ($password, $contentType) {
+            ->willReturnCallback(function (string $actualPassword, PasswordValidationContext $actualContext) use (
+                $password,
+                $contentType
+            ): array {
                 $this->assertEquals($password, $actualPassword);
                 $this->assertInstanceOf(PasswordValidationContext::class, $actualContext);
                 $this->assertSame($contentType, $actualContext->contentType);
@@ -78,7 +81,7 @@ class PasswordValidatorTest extends TestCase
         ]));
     }
 
-    public function testInvalid()
+    public function testInvalid(): void
     {
         $contentType = $this->createMock(ContentType::class);
         $password = 'pass';
@@ -88,7 +91,12 @@ class PasswordValidatorTest extends TestCase
         $this->userService
             ->expects($this->once())
             ->method('validatePassword')
-            ->willReturnCallback(function ($actualPassword, $actualContext) use ($password, $contentType, $errorMessage, $errorParameter) {
+            ->willReturnCallback(function (string $actualPassword, PasswordValidationContext $actualContext) use (
+                $password,
+                $contentType,
+                $errorMessage,
+                $errorParameter
+            ): array {
                 $this->assertEquals($password, $actualPassword);
                 $this->assertInstanceOf(PasswordValidationContext::class, $actualContext);
                 $this->assertSame($contentType, $actualContext->contentType);

--- a/tests/lib/Validator/Constraint/PasswordValidatorTest.php
+++ b/tests/lib/Validator/Constraint/PasswordValidatorTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUser\Tests\Validator\Constraint;
+
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\User\PasswordValidationContext;
+use eZ\Publish\Core\FieldType\ValidationError;
+use EzSystems\EzPlatformUser\Validator\Constraints\Password;
+use EzSystems\EzPlatformUser\Validator\Constraints\PasswordValidator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class PasswordValidatorTest extends TestCase
+{
+    /** @var \eZ\Publish\API\Repository\UserService|\PHPUnit\Framework\MockObject\MockObject */
+    private $userService;
+
+    /** @var \PHPUnit\Framework\MockObject\MockObject|\Symfony\Component\Validator\Context\ExecutionContextInterface */
+    private $executionContext;
+
+    /** @var \EzSystems\EzPlatformUser\Validator\Constraints\PasswordValidator */
+    private $validator;
+
+    protected function setUp(): void
+    {
+        $this->userService = $this->createMock(UserService::class);
+        $this->executionContext = $this->createMock(ExecutionContextInterface::class);
+        $this->validator = new PasswordValidator($this->userService);
+        $this->validator->initialize($this->executionContext);
+    }
+
+    /**
+     * @dataProvider dataProviderForValidateNotSupportedValueType
+     */
+    public function testValidateShouldBeSkipped($value)
+    {
+        $this->userService
+            ->expects($this->never())
+            ->method('validatePassword');
+
+        $this->executionContext
+            ->expects($this->never())
+            ->method('buildViolation');
+
+        $this->validator->validate($value, new Password());
+    }
+
+    public function testValid()
+    {
+        $password = 'pass';
+        $contentType = $this->createMock(ContentType::class);
+
+        $this->userService
+            ->expects($this->once())
+            ->method('validatePassword')
+            ->willReturnCallback(function ($actualPassword, $actualContext) use ($password, $contentType) {
+                $this->assertEquals($password, $actualPassword);
+                $this->assertInstanceOf(PasswordValidationContext::class, $actualContext);
+                $this->assertSame($contentType, $actualContext->contentType);
+
+                return [];
+            });
+
+        $this->executionContext
+            ->expects($this->never())
+            ->method('buildViolation');
+
+        $this->validator->validate($password, new Password([
+            'contentType' => $contentType,
+        ]));
+    }
+
+    public function testInvalid()
+    {
+        $contentType = $this->createMock(ContentType::class);
+        $password = 'pass';
+        $errorParameter = 'foo';
+        $errorMessage = 'error';
+
+        $this->userService
+            ->expects($this->once())
+            ->method('validatePassword')
+            ->willReturnCallback(function ($actualPassword, $actualContext) use ($password, $contentType, $errorMessage, $errorParameter) {
+                $this->assertEquals($password, $actualPassword);
+                $this->assertInstanceOf(PasswordValidationContext::class, $actualContext);
+                $this->assertSame($contentType, $actualContext->contentType);
+
+                return [
+                    new ValidationError($errorMessage, null, ['%foo%' => $errorParameter]),
+                ];
+            });
+
+        $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
+
+        $this->executionContext
+            ->expects($this->once())
+            ->method('buildViolation')
+            ->willReturn($constraintViolationBuilder);
+        $this->executionContext
+            ->expects($this->once())
+            ->method('buildViolation')
+            ->with($errorMessage)
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder
+            ->expects($this->once())
+            ->method('setParameters')
+            ->with(['%foo%' => $errorParameter])
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder
+            ->expects($this->once())
+            ->method('addViolation');
+
+        $this->validator->validate('pass', new Password([
+            'contentType' => $contentType,
+        ]));
+    }
+
+    public function dataProviderForValidateNotSupportedValueType(): array
+    {
+        return [
+            [new \stdClass()],
+            [null],
+            [''],
+        ];
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  https://jira.ez.no/browse/EZP-31017
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes (but not sure if it is covered by BC policy - mandatory option for FormType)
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

As a part of removing circular dependencies between `ezplatform-user` and `ezplatform-admin-ui` I moved validators in question into this repository.

I have also deprecated passing contentType as part of data class as it should from start be passed as form option and removed deprecated routing aliases.

## Additional PRs:
https://github.com/ezsystems/ezplatform-content-forms/pull/24
https://github.com/ezsystems/ezplatform-admin-ui/pull/1348

#### Checklist:
- [x] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
