### PR TITLE
EZP-31668: Introduced new key for user related pagination configuration

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
@@ -26,16 +26,11 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  */
 class Pagination extends AbstractParser
 {
-    /**
-     * Adds semantic configuration definition.
-     *
-     * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ezpublish.system.<siteaccess>
-     */
     public function addSemanticConfig(NodeBuilder $nodeBuilder)
     {
         $nodeBuilder
-            ->arrayNode('pagination')
-                ->info('System pagination configuration')
+            ->arrayNode('pagination_user')
+                ->info('user related pagination configuration')
                 ->children()
                     ->scalarNode('user_settings_limit')->isRequired()->end()
                 ->end()
@@ -47,11 +42,11 @@ class Pagination extends AbstractParser
      */
     public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
     {
-        if (empty($scopeSettings['pagination'])) {
+        if (empty($scopeSettings['pagination_user'])) {
             return;
         }
 
-        $settings = $scopeSettings['pagination'];
+        $settings = $scopeSettings['pagination_user'];
         $keys = [
             'user_settings_limit',
         ];
@@ -62,7 +57,7 @@ class Pagination extends AbstractParser
             }
 
             $contextualizer->setContextualParameter(
-                sprintf('pagination.%s', $key),
+                sprintf('pagination_user.%s', $key),
                 $currentScope,
                 $settings[$key]
             );

--- a/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
@@ -20,7 +20,7 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  * ezpublish:
  *   system:
  *      default: # configuration per siteaccess or siteaccess group
- *          pagination:
+ *          pagination_user:
  *              user_settings_limit: 10
  * ```
  */

--- a/src/bundle/Resources/config/ezplatform_default_settings.yml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yml
@@ -58,4 +58,4 @@ parameters:
     ezsettings.default.user_preferences.additional_translations: []
 
     # Pagination limits
-    ezsettings.default.pagination.user_settings_limit: 10
+    ezsettings.default.pagination_user.user_settings_limit: 10

--- a/src/bundle/Resources/config/services/controllers.yml
+++ b/src/bundle/Resources/config/services/controllers.yml
@@ -37,4 +37,4 @@ services:
     EzSystems\EzPlatformUserBundle\Controller\UserSettingsController:
         parent: EzSystems\EzPlatformAdminUiBundle\Controller\Controller
         arguments:
-            $defaultPaginationLimit: '$pagination.user_settings_limit$'
+            $defaultPaginationLimit: '$pagination_user.user_settings_limit$'


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-31668](https://jira.ez.no/browse/EZP-31668) <!-- URLs to JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

This is counterproposition to https://github.com/ezsystems/ezplatform-user/pull/41 that fix the issue in the easiest way, as it seems those parameters are not widely used this seems to be safe change in terms of making all other pagination parameters accessible.

it is now:

```
ezpublish:
   system:
     default:
           pagination_user: # <-- new
               user_settings_limit: 10
```

instead of

```
ezpublish:
   system:
     default: 
           pagination: # <-- old
               user_settings_limit: 10
```

https://github.com/ezsystems/ezplatform-admin-ui/pull/1394

#### Checklist:
- [x] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
