### PR TITLE
EZP-31462: Add handling unsupported password hash type by redirection to a password reset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ cache:
   directories:
   - "$HOME/.composer/cache/files"
 
+env:
+  global:
+    - EZPLATFORM_REPO="https://github.com/ezsystems/ezplatform.git"
+    - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
+    - APP_ENV=behat
+    - APP_DEBUG=1
+
 matrix:
   fast_finish: true
   include:
@@ -16,6 +23,9 @@ matrix:
   - name: Code Style Check
     php: 7.3
     env: CHECK_CS=1
+  - name: "User Integration tests"
+    env:
+      - BEHAT_OPTS="--profile=user --suite=browser"
 
 branches:
   only:
@@ -28,12 +38,20 @@ before_install:
 - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}
 
 install:
-- travis_retry composer install --prefer-dist --no-interaction --no-suggest
+  - if [ "${CHECK_CS}" == "1" -o "${TEST_CONFIG}" != "" ]; then travis_retry composer install --prefer-dist --no-interaction --no-suggest ; fi
+  - if [ "${BEHAT_OPTS}" != "" ]; then ./.travis/prepare_ezplatform.sh ${INSTALL_EZ_INSTALL_TYPE}; fi
+
+before_script:
+  - if [ "${SETUP_BEHAT_OPTS}" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/ezbehat $SETUP_BEHAT_OPTS" ; fi
 
 script:
-- if [ "$TEST_CONFIG" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1
-  vendor/bin/phpunit -c $TEST_CONFIG ; fi
-- if [ "$CHECK_CS" == "1" ] ; then ./vendor/bin/php-cs-fixer fix -v --dry-run --show-progress=estimating; fi
+  - if [ "$TEST_CONFIG" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1
+    vendor/bin/phpunit -c $TEST_CONFIG ; fi
+  - if [ "$CHECK_CS" == "1" ] ; then ./vendor/bin/php-cs-fixer fix -v --dry-run --show-progress=estimating; fi
+  - if [ "${BEHAT_OPTS}" != "" ]; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/ezbehat ${BEHAT_OPTS}" ; fi
+
+after_script:
+  - if [ "${BEHAT_OPTS}" != "" ] ; then bin/ezreport ; fi
 
 notifications:
   slack:

--- a/.travis/prepare_ezplatform.sh
+++ b/.travis/prepare_ezplatform.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+EZPLATFORM_BRANCH=`php -r 'echo json_decode(file_get_contents("./composer.json"))->extra->_ezplatform_branch_for_behat_tests;'`
+EZPLATFORM_BRANCH="${EZPLATFORM_BRANCH:-master}"
+PACKAGE_BUILD_DIR=$PWD
+EZPLATFORM_BUILD_DIR=${HOME}/build/ezplatform
+
+echo "> Cloning ezsystems/ezplatform:${EZPLATFORM_BRANCH}"
+git clone --depth 1 --single-branch --branch "${EZPLATFORM_BRANCH}" ${EZPLATFORM_REPO} ${EZPLATFORM_BUILD_DIR}
+cd ${EZPLATFORM_BUILD_DIR}
+
+# Copy over auth.json
+cp $TRAVIS_BUILD_DIR/auth.json .
+
+/bin/bash ./bin/.travis/trusty/setup_ezplatform.sh "${COMPOSE_FILE}" '' "${PACKAGE_BUILD_DIR}"

--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -1,0 +1,12 @@
+user:
+    suites:
+        browser:
+            paths:
+              - '%paths.base%/vendor/ezsystems/ezplatform-user/features/browser'
+            contexts:
+              - EzSystems\Behat\API\Context\TestContext
+              - EzSystems\Behat\API\Context\UserContext
+              - EzSystems\EzPlatformUser\Tests\Behat\Context\UserSetupContext
+              - EzSystems\Behat\Browser\Context\BrowserContext
+              - EzSystems\Behat\Browser\Context\FrontendContext
+              - EzSystems\Behat\Browser\Context\Hooks

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": "GPL-2.0-only",
     "autoload": {
         "psr-4": {
+            "EzSystems\\EzPlatformUser\\Tests\\Behat\\": "tests/Behat/",
             "EzSystems\\EzPlatformUserBundle\\": "src/bundle/",
             "EzSystems\\EzPlatformUser\\": "src/lib/"
         }
@@ -33,7 +34,8 @@
         "symfony/form": "^5.0",
         "symfony/routing": "^5.0",
         "symfony/swiftmailer-bundle": "^3.4",
-        "twig/twig": "^3.0"
+        "twig/twig": "^3.0",
+        "symfony/security-http": "^5.0"
     },
     "require-dev": {
         "ezsystems/doctrine-dbal-schema": "^1.0@dev",
@@ -50,8 +52,10 @@
         "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
     },
     "extra": {
+        "_ezplatform_branch_for_behat_tests": "3.1",
         "branch-alias": {
-            "dev-master": "2.1.x-dev"
+            "dev-master": "2.1.x-dev",
+            "dev-tmp_ci_branch": "2.1.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
     },
     "extra": {
-        "_ezplatform_branch_for_behat_tests": "3.1",
+        "_ezplatform_branch_for_behat_tests": "fix/EZP-31462-handle-users-with-unsupported-password-hash-types",
         "branch-alias": {
             "dev-master": "2.1.x-dev",
             "dev-tmp_ci_branch": "2.1.x-dev"

--- a/features/browser/signIn.feature
+++ b/features/browser/signIn.feature
@@ -1,0 +1,9 @@
+  Feature: As an user I can sign in using form
+
+  @admin
+  Scenario: User is asked for setting a new password when his password is in an unsupported format
+    Given I create a user "UnsupportedPasswordUser" with last name "User" in group "Anonymous Users"
+    And a user "UnsupportedPasswordUser" has password in unsupported format
+    When I am viewing the pages on siteaccess "site" as "UnsupportedPasswordUser"
+    Then the url should match "/site/user/forgot-password/migration"
+    And I should see "Your password has expired"

--- a/src/bundle/Controller/PasswordResetController.php
+++ b/src/bundle/Controller/PasswordResetController.php
@@ -21,6 +21,7 @@ use EzSystems\EzPlatformUser\View\ForgotPassword\SuccessView;
 use EzSystems\EzPlatformUser\View\ResetPassword\InvalidLinkView;
 use EzSystems\EzPlatformUser\View\ResetPassword\FormView as UserResetPasswordFormView;
 use EzSystems\EzPlatformUser\View\ResetPassword\SuccessView as UserResetPasswordSuccessView;
+use EzSystems\EzPlatformUserBundle\Type\UserForgotPasswordReason;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use eZ\Publish\API\Repository\UserService;
@@ -104,6 +105,7 @@ class PasswordResetController extends Controller
         return new FormView(null, [
             'form_forgot_user_password' => $form->createView(),
             'reason' => $reason,
+            'userForgotPasswordReasonMigration' => UserForgotPasswordReason::MIGRATION,
         ]);
     }
 

--- a/src/bundle/Controller/PasswordResetController.php
+++ b/src/bundle/Controller/PasswordResetController.php
@@ -73,13 +73,11 @@ class PasswordResetController extends Controller
     }
 
     /**
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     *
      * @return \EzSystems\EzPlatformUser\View\ForgotPassword\FormView|\EzSystems\EzPlatformUser\View\ForgotPassword\SuccessView|\Symfony\Component\HttpFoundation\RedirectResponse
      *
      * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
      */
-    public function userForgotPasswordAction(Request $request)
+    public function userForgotPasswordAction(Request $request, ?string $reason = null)
     {
         $form = $this->formFactory->forgotUserPassword();
         $form->handleRequest($request);
@@ -105,6 +103,7 @@ class PasswordResetController extends Controller
 
         return new FormView(null, [
             'form_forgot_user_password' => $form->createView(),
+            'reason' => $reason,
         ]);
     }
 

--- a/src/bundle/DependencyInjection/Compiler/SecurityPass.php
+++ b/src/bundle/DependencyInjection/Compiler/SecurityPass.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUserBundle\DependencyInjection\Compiler;
+
+use EzSystems\EzPlatformUserBundle\Security\Authentication\DefaultAuthenticationFailureHandler;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class SecurityPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if ($container->hasDefinition('security.authentication.failure_handler')) {
+            $failureHandlerDef = $container->getDefinition('security.authentication.failure_handler');
+            $failureHandlerDef->setClass(DefaultAuthenticationFailureHandler::class);
+        }
+    }
+}

--- a/src/bundle/DependencyInjection/EzPlatformUserExtension.php
+++ b/src/bundle/DependencyInjection/EzPlatformUserExtension.php
@@ -26,6 +26,11 @@ class EzPlatformUserExtension extends Extension implements PrependExtensionInter
             new FileLocator(__DIR__ . '/../Resources/config')
         );
 
+        $environment = $container->getParameter('kernel.environment');
+        if ($environment === 'behat') {
+            $loader->load('services/feature_contexts.yaml');
+        }
+
         $loader->load('services.yaml');
     }
 

--- a/src/bundle/EzPlatformUserBundle.php
+++ b/src/bundle/EzPlatformUserBundle.php
@@ -6,6 +6,7 @@
  */
 namespace EzSystems\EzPlatformUserBundle;
 
+use EzSystems\EzPlatformUserBundle\DependencyInjection\Compiler\SecurityPass;
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Compiler\UserSetting;
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\ChangePassword;
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\Pagination;
@@ -35,6 +36,7 @@ class EzPlatformUserBundle extends Bundle
         $container->addCompilerPass(new UserSetting\ValueDefinitionPass());
         $container->addCompilerPass(new UserSetting\FormMapperPass());
         $container->addCompilerPass(new UserSetting\ViewBuilderRegistryPass());
+        $container->addCompilerPass(new SecurityPass());
 
         $core->addDefaultSettings(__DIR__ . '/Resources/config', ['ezplatform_default_settings.yaml']);
     }

--- a/src/bundle/Resources/config/routing.yaml
+++ b/src/bundle/Resources/config/routing.yaml
@@ -12,6 +12,12 @@ ezplatform.user.forgot_password:
     defaults:
         _controller: 'EzSystems\EzPlatformUserBundle\Controller\PasswordResetController::userForgotPasswordAction'
 
+ezplatform.user.forgot_password.migration:
+    path: /user/forgot-password/migration
+    defaults:
+        _controller: 'EzSystems\EzPlatformUserBundle\Controller\PasswordResetController::userForgotPasswordAction'
+        reason: 'migration'
+
 ezplatform.user.forgot_password.login:
     path: /user/forgot-password/login
     defaults:

--- a/src/bundle/Resources/config/services/feature_contexts.yaml
+++ b/src/bundle/Resources/config/services/feature_contexts.yaml
@@ -1,0 +1,9 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    EzSystems\EzPlatformUser\Tests\Behat\Context\UserSetupContext:
+        arguments:
+            - '@ezpublish.persistence.connection'

--- a/src/bundle/Resources/translations/forgot_password.en.xliff
+++ b/src/bundle/Resources/translations/forgot_password.en.xliff
@@ -39,8 +39,8 @@
         <note>key: ezplatform.forgot_password.reset_your_password</note>
       </trans-unit>
       <trans-unit id="8c3f0606ebb870dd8113cca42da7510414c5a0a8" resname="ezplatform.forgot_password.reset_your_password.reason.migration">
-        <source>Your password has expired, change it!</source>
-        <target state="new">Your password has expired, change it!</target>
+        <source>Your password has expired, change it.</source>
+        <target state="new">Your password has expired, change it.</target>
         <note>key: ezplatform.forgot_password.reset_your_password.reason.migration</note>
       </trans-unit>
       <trans-unit id="9b35c814c4edde4e4ecc46eef81c1be1821601ba" resname="ezplatform.forgot_password.success">

--- a/src/bundle/Resources/translations/forgot_password.en.xliff
+++ b/src/bundle/Resources/translations/forgot_password.en.xliff
@@ -38,6 +38,11 @@
         <target state="new">Reset your password</target>
         <note>key: ezplatform.forgot_password.reset_your_password</note>
       </trans-unit>
+      <trans-unit id="8c3f0606ebb870dd8113cca42da7510414c5a0a8" resname="ezplatform.forgot_password.reset_your_password.reason.migration">
+        <source>Your password has expired, change it!</source>
+        <target state="new">Your password has expired, change it!</target>
+        <note>key: ezplatform.forgot_password.reset_your_password.reason.migration</note>
+      </trans-unit>
       <trans-unit id="9b35c814c4edde4e4ecc46eef81c1be1821601ba" resname="ezplatform.forgot_password.success">
         <source><![CDATA[<p>An email has been sent with instructions on how to reset your account password.</p>
             <p>If the email is slow to arrive, check your spam folders.</p>

--- a/src/bundle/Resources/views/forgot_password/index.html.twig
+++ b/src/bundle/Resources/views/forgot_password/index.html.twig
@@ -4,6 +4,9 @@
 
 {% block content %}
     <h2>{{ 'ezplatform.forgot_password.reset_your_password'|trans|desc('Reset your password') }}</h2>
+    {% if reason is defined and reason == constant('\\EzSystems\\EzPlatformUserBundle\\Type\\UserForgotPasswordReason::MIGRATION') %}
+        <h3>{{ 'ezplatform.forgot_password.reset_your_password.reason.migration'|trans|desc('Your password has expired, change it!') }}</h3>
+    {% endif %}
     {{ form_start(form_forgot_user_password) }}
     {{ form_widget(form_forgot_user_password) }}
     {{ form_end(form_forgot_user_password) }}

--- a/src/bundle/Resources/views/forgot_password/index.html.twig
+++ b/src/bundle/Resources/views/forgot_password/index.html.twig
@@ -5,7 +5,7 @@
 {% block content %}
     <h2>{{ 'ezplatform.forgot_password.reset_your_password'|trans|desc('Reset your password') }}</h2>
     {% if reason is defined and reason == userForgotPasswordReasonMigration %}
-        <h3>{{ 'ezplatform.forgot_password.reset_your_password.reason.migration'|trans|desc('Your password has expired, change it!') }}</h3>
+        <h3>{{ 'ezplatform.forgot_password.reset_your_password.reason.migration'|trans|desc('Your password has expired, change it.') }}</h3>
     {% endif %}
     {{ form_start(form_forgot_user_password) }}
     {{ form_widget(form_forgot_user_password) }}

--- a/src/bundle/Resources/views/forgot_password/index.html.twig
+++ b/src/bundle/Resources/views/forgot_password/index.html.twig
@@ -4,7 +4,7 @@
 
 {% block content %}
     <h2>{{ 'ezplatform.forgot_password.reset_your_password'|trans|desc('Reset your password') }}</h2>
-    {% if reason is defined and reason == constant('\\EzSystems\\EzPlatformUserBundle\\Type\\UserForgotPasswordReason::MIGRATION') %}
+    {% if reason is defined and reason == userForgotPasswordReasonMigration %}
         <h3>{{ 'ezplatform.forgot_password.reset_your_password.reason.migration'|trans|desc('Your password has expired, change it!') }}</h3>
     {% endif %}
     {{ form_start(form_forgot_user_password) }}

--- a/src/bundle/Security/Authentication/DefaultAuthenticationFailureHandler.php
+++ b/src/bundle/Security/Authentication/DefaultAuthenticationFailureHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUserBundle\Security\Authentication;
+
+use eZ\Publish\API\Repository\Exceptions\PasswordInUnsupportedFormatException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler as HttpDefaultAuthenticationFailureHandler;
+
+final class DefaultAuthenticationFailureHandler extends HttpDefaultAuthenticationFailureHandler
+{
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    {
+        if ($exception instanceof PasswordInUnsupportedFormatException) {
+            $resetPasswordUrl = $this->httpUtils->generateUri($request, 'ezplatform.user.forgot_password.migration');
+            $this->setOptions([
+                'failure_path' => $resetPasswordUrl,
+            ]);
+        }
+
+        return parent::onAuthenticationFailure($request, $exception);
+    }
+}

--- a/src/bundle/Type/UserForgotPasswordReason.php
+++ b/src/bundle/Type/UserForgotPasswordReason.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUserBundle\Type;
+
+class UserForgotPasswordReason
+{
+    public const MIGRATION = 'migration';
+}

--- a/tests/Behat/Context/UserSetupContext.php
+++ b/tests/Behat/Context/UserSetupContext.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUser\Tests\Behat\Context;
+
+use Behat\Behat\Context\Context;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+
+class UserSetupContext implements Context
+{
+    private const UNSUPPORTED_USER_HASH = 5;
+
+    /** @var \Doctrine\DBAL\Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * @Given a user :login has password in unsupported format
+     */
+    public function aUserHasPasswordInUnsupportedFormat(string $login): void
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+        $update = $queryBuilder
+            ->update('ezuser', 'u')
+            ->set('u.password_hash_type', self::UNSUPPORTED_USER_HASH)
+            ->andWhere(
+                $queryBuilder->expr()->eq('u.login', ':login')
+            )
+            ->setParameter(':login', $login, ParameterType::STRING);
+
+        $update->execute();
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-31462](https://jira.ez.no/browse/EZP-31462)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | ?
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


In order to handle users with unsupported hash types redirection to "Password reset" was added


#### Checklist:
- [x] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
