### PR TITLE
EZP-31941: A row in the tables under Admin panel should have a gray background on hover over (Same as rest of the application)

### DIFF
--- a/src/bundle/Resources/views/user_settings/list.html.twig
+++ b/src/bundle/Resources/views/user_settings/list.html.twig
@@ -33,7 +33,7 @@
     {% endif %}
 
     <h2>{{ 'my_account_settings.password.title'|trans|desc('Password') }}</h2>
-    <table class="table">
+    <table class="table table-hover">
         <tbody>
             <tr>
                 <td>


### PR DESCRIPTION
JIRA ref: https://jira.ez.no/browse/EZP-31941