### PR TITLE
EZP-32164: Removed obsolete `icon_url` property from menu items

### DIFF
--- a/src/lib/EventListener/UserMenuListener.php
+++ b/src/lib/EventListener/UserMenuListener.php
@@ -52,7 +52,6 @@ class UserMenuListener implements EventSubscriberInterface, TranslationContainer
                     'route' => 'ezplatform.user_profile.change_password',
                     'extras' => [
                         'translation_domain' => 'menu',
-                        'icon_url' => '/bundles/ezplatformadminuiassets/vendors/webalys/streamlineicons/all-icons.svg#edit',
                         'orderNumber' => 40,
                     ],
                 ]


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-32164](https://jira.ez.no/browse/EZP-32164) <!-- URLs to JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

