### PR TITLE
IBX-215: Added semantic configuration for password related views

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "ezsystems/ezplatform-rest": "^1.0@dev",
         "friendsofphp/php-cs-fixer": "^2.16.0",
         "ezsystems/ezplatform-code-style": "^0.1.0",
-        "phpunit/phpunit": "^8.2"
+        "phpunit/phpunit": "^8.2",
+        "matthiasnoback/symfony-dependency-injection-test": "4.1"
     },
     "scripts": {
         "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"

--- a/src/bundle/DependencyInjection/Configuration/Parser/ForgotPassword.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/ForgotPassword.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+class ForgotPassword extends AbstractParser
+{
+    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    {
+        $nodeBuilder
+            ->arrayNode('user_forgot_password')
+                ->info('User forgot password configuration')
+                ->children()
+                    ->arrayNode('templates')
+                        ->children()
+                            ->scalarNode('form')
+                                ->info('Template to use for forgot password form rendering.')
+                            ->end()
+                            ->scalarNode('mail')
+                                ->info('Template to use for forgot password mail with reset link.')
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+            ->arrayNode('user_forgot_password_success')
+                ->info('User forgot password success configuration')
+                ->children()
+                    ->arrayNode('templates')
+                        ->children()
+                            ->scalarNode('form')
+                                ->info('Template to use for success forgot password form rendering.')
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+            ->arrayNode('user_forgot_password_login')
+                ->info('User forgot password with login configuration')
+                ->children()
+                    ->arrayNode('templates')
+                        ->children()
+                            ->scalarNode('form')
+                                ->info('Template to use for forgot password with login form .')
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ->end()
+        ;
+    }
+
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    {
+        if (!empty($scopeSettings['user_forgot_password'])) {
+            $settings = $scopeSettings['user_forgot_password']['templates'];
+            if (!empty($settings['form'])) {
+                $contextualizer->setContextualParameter(
+                    'user_forgot_password.templates.form',
+                    $currentScope,
+                    $settings['form']
+                );
+            }
+            if (!empty($settings['mail'])) {
+                $contextualizer->setContextualParameter(
+                    'user_forgot_password.templates.mail',
+                    $currentScope,
+                    $settings['mail']
+                );
+            }
+        }
+
+        if (!empty($scopeSettings['user_forgot_password_success'])) {
+            $settings = $scopeSettings['user_forgot_password_success']['templates'];
+            $contextualizer->setContextualParameter(
+                'user_forgot_password_success.templates.form',
+                $currentScope,
+                $settings['form']
+            );
+        }
+
+        if (!empty($scopeSettings['user_forgot_password_login'])) {
+            $settings = $scopeSettings['user_forgot_password_login']['templates'];
+            $contextualizer->setContextualParameter(
+                'user_forgot_password_login.templates.form',
+                $currentScope,
+                $settings['form']
+            );
+        }
+    }
+}

--- a/src/bundle/DependencyInjection/Configuration/Parser/ForgotPassword.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/ForgotPassword.php
@@ -12,7 +12,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractPars
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
-class ForgotPassword extends AbstractParser
+final class ForgotPassword extends AbstractParser
 {
     public function addSemanticConfig(NodeBuilder $nodeBuilder)
     {

--- a/src/bundle/DependencyInjection/Configuration/Parser/ResetPassword.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/ResetPassword.php
@@ -12,7 +12,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractPars
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
-class ResetPassword extends AbstractParser
+final class ResetPassword extends AbstractParser
 {
     public function addSemanticConfig(NodeBuilder $nodeBuilder)
     {

--- a/src/bundle/DependencyInjection/Configuration/Parser/ResetPassword.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/ResetPassword.php
@@ -12,55 +12,59 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractPars
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
-class ChangePassword extends AbstractParser
+class ResetPassword extends AbstractParser
 {
-    /**
-     * Adds semantic configuration definition.
-     *
-     * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ezpublish.system.<siteaccess>
-     */
     public function addSemanticConfig(NodeBuilder $nodeBuilder)
     {
         $nodeBuilder
-            ->arrayNode('user_change_password')
-                ->info('User change password configuration')
+            ->arrayNode('user_reset_password')
+                ->info('User reset password configuration')
                 ->children()
                     ->arrayNode('templates')
-                        ->info('User change password templates.')
                         ->children()
                             ->scalarNode('form')
-                                ->info('Template to use for change password form rendering.')
+                                ->info('Template to use for reset password form rendering.')
+                            ->end()
+                            ->scalarNode('invalid_link')
+                                ->info('Template to use for error with invalid reset link.')
                             ->end()
                             ->scalarNode('success')
-                                ->info('Template to use for change password success view.')
+                                ->info('Template to use for reset password success view.')
                             ->end()
                         ->end()
                     ->end()
                 ->end()
-            ->end();
+            ->end()
+        ->end()
+        ;
     }
 
     public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
     {
-        if (empty($scopeSettings['user_change_password'])) {
+        if (empty($scopeSettings['user_reset_password'])) {
             return;
         }
 
-        $settings = $scopeSettings['user_change_password'];
-
-        if (!empty($settings['templates']['form'])) {
+        $settings = $scopeSettings['user_reset_password']['templates'];
+        if (!empty($settings['form'])) {
             $contextualizer->setContextualParameter(
-                'user_change_password.templates.form',
+                'user_reset_password.templates.form',
                 $currentScope,
-                $settings['templates']['form']
+                $settings['form']
             );
         }
-
-        if (!empty($settings['templates']['success'])) {
+        if (!empty($settings['invalid_link'])) {
             $contextualizer->setContextualParameter(
-                'user_change_password.templates.success',
+                'user_reset_password.templates.invalid_link',
                 $currentScope,
-                $settings['templates']['success']
+                $settings['invalid_link']
+            );
+        }
+        if (!empty($settings['success'])) {
+            $contextualizer->setContextualParameter(
+                'user_reset_password.templates.success',
+                $currentScope,
+                $settings['success']
             );
         }
     }

--- a/src/bundle/EzPlatformUserBundle.php
+++ b/src/bundle/EzPlatformUserBundle.php
@@ -9,7 +9,9 @@ namespace EzSystems\EzPlatformUserBundle;
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Compiler\SecurityPass;
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Compiler\UserSetting;
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\ChangePassword;
+use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\ForgotPassword;
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\Pagination;
+use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\ResetPassword;
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\UserPreferences;
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\UserRegistration;
 use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\Security;
@@ -32,6 +34,8 @@ class EzPlatformUserBundle extends Bundle
         $core->addConfigParser(new UserRegistration());
         $core->addConfigParser(new UserPreferences());
         $core->addConfigParser(new UserSettingsUpdateView());
+        $core->addConfigParser(new ForgotPassword());
+        $core->addConfigParser(new ResetPassword());
 
         $container->addCompilerPass(new UserSetting\ValueDefinitionPass());
         $container->addCompilerPass(new UserSetting\FormMapperPass());

--- a/tests/bundle/DependencyInjection/Configuration/Parser/ChangePasswordTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/ChangePasswordTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\Tests\Bundle\OAuth2Client\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
+use eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser\AbstractParserTestCase;
+use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\ChangePassword;
+use EzSystems\EzPlatformUserBundle\DependencyInjection\EzPlatformUserExtension;
+
+final class ChangePasswordTest extends AbstractParserTestCase
+{
+    protected function getContainerExtensions(): array
+    {
+        return [
+            new EzPublishCoreExtension([
+                new ChangePassword(),
+            ]),
+            new EzPlatformUserExtension(),
+        ];
+    }
+
+    protected function getMinimalConfiguration(): array
+    {
+        return [
+            'system' => [
+                'default' => [
+                    'user_change_password' => [
+                        'templates' => [
+                            'form' => 'default/path/template.html.twig',
+                        ]
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function testDefaultSettings(): void
+    {
+        $this->load();
+
+        $this->assertConfigResolverParameterValue(
+            'user_change_password.templates.form',
+            'default/path/template.html.twig',
+            'ezdemo_site'
+        );
+    }
+
+    public function testOverwrittenConfig()
+    {
+        $this->load([
+            'system' => [
+                'ezdemo_site' => [
+                    'user_change_password' => [
+                        'templates' => [
+                            'form' => '@yourOwnBundle/path/to/template.html.twig',
+                            'success' => '@yourOwnBundle/path/to/success.html.twig',
+                        ]
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertConfigResolverParameterValue(
+            'user_change_password.templates.form',
+            '@yourOwnBundle/path/to/template.html.twig',
+            'ezdemo_site'
+        );
+        $this->assertConfigResolverParameterValue(
+            'user_change_password.templates.success',
+            '@yourOwnBundle/path/to/success.html.twig',
+            'ezdemo_site'
+        );
+    }
+}

--- a/tests/bundle/DependencyInjection/Configuration/Parser/ForgotPasswordTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/ForgotPasswordTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\Tests\Bundle\OAuth2Client\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
+use eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser\AbstractParserTestCase;
+use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\ForgotPassword;
+use EzSystems\EzPlatformUserBundle\DependencyInjection\EzPlatformUserExtension;
+
+final class ForgotPasswordTest extends AbstractParserTestCase
+{
+    protected function getContainerExtensions(): array
+    {
+        return [
+            new EzPublishCoreExtension([
+                new ForgotPassword(),
+            ]),
+            new EzPlatformUserExtension(),
+        ];
+    }
+
+    protected function getMinimalConfiguration(): array
+    {
+        return [
+            'system' => [
+                'default' => [
+                    'user_forgot_password' => [
+                        'templates' => [
+                            'form' => 'default/path/template.html.twig',
+                        ]
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function testDefaultSettings(): void
+    {
+        $this->load();
+
+        $this->assertConfigResolverParameterValue(
+            'user_forgot_password.templates.form',
+            'default/path/template.html.twig',
+            'ezdemo_site'
+        );
+    }
+
+    public function testOverwrittenConfig()
+    {
+        $this->load([
+            'system' => [
+                'ezdemo_site' => [
+                    'user_forgot_password' => [
+                        'templates' => [
+                            'form' => '@yourOwnBundle/path/to/template.html.twig',
+                            'mail' => '@yourOwnBundle/path/to/mail.html.twig',
+                        ]
+                    ],
+                    'user_forgot_password_success' => [
+                        'templates' => [
+                            'form' => '@yourOwnBundle/path/to/template_success.html.twig',
+                        ]
+                    ],
+                    'user_forgot_password_login' => [
+                        'templates' => [
+                            'form' => '@yourOwnBundle/path/to/template_login.html.twig',
+                        ]
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertConfigResolverParameterValue(
+            'user_forgot_password.templates.form',
+            '@yourOwnBundle/path/to/template.html.twig',
+            'ezdemo_site'
+        );
+        $this->assertConfigResolverParameterValue(
+            'user_forgot_password.templates.mail',
+            '@yourOwnBundle/path/to/mail.html.twig',
+            'ezdemo_site'
+        );
+        $this->assertConfigResolverParameterValue(
+            'user_forgot_password_success.templates.form',
+            '@yourOwnBundle/path/to/template_success.html.twig',
+            'ezdemo_site'
+        );
+        $this->assertConfigResolverParameterValue(
+            'user_forgot_password_login.templates.form',
+            '@yourOwnBundle/path/to/template_login.html.twig',
+            'ezdemo_site'
+        );
+    }
+}

--- a/tests/bundle/DependencyInjection/Configuration/Parser/ResetPasswordTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/ResetPasswordTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\Tests\Bundle\OAuth2Client\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
+use eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser\AbstractParserTestCase;
+use EzSystems\EzPlatformUserBundle\DependencyInjection\Configuration\Parser\ResetPassword;
+use EzSystems\EzPlatformUserBundle\DependencyInjection\EzPlatformUserExtension;
+
+final class ResetPasswordTest extends AbstractParserTestCase
+{
+    protected function getContainerExtensions(): array
+    {
+        return [
+            new EzPublishCoreExtension([
+                new ResetPassword(),
+            ]),
+            new EzPlatformUserExtension(),
+        ];
+    }
+
+    protected function getMinimalConfiguration(): array
+    {
+        return [
+            'system' => [
+                'default' => [
+                    'user_reset_password' => [
+                        'templates' => [
+                            'form' => 'default/path/template.html.twig',
+                        ]
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function testDefaultSettings(): void
+    {
+        $this->load();
+
+        $this->assertConfigResolverParameterValue(
+            'user_reset_password.templates.form',
+            'default/path/template.html.twig',
+            'ezdemo_site'
+        );
+    }
+
+    public function testOverwrittenConfig()
+    {
+        $this->load([
+            'system' => [
+                'ezdemo_site' => [
+                    'user_reset_password' => [
+                        'templates' => [
+                            'form' => '@yourOwnBundle/path/to/template.html.twig',
+                            'invalid_link' => '@yourOwnBundle/path/to/invalid_link.html.twig',
+                            'success' => '@yourOwnBundle/path/to/success.html.twig'
+                        ]
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertConfigResolverParameterValue(
+            'user_reset_password.templates.form',
+            '@yourOwnBundle/path/to/template.html.twig',
+            'ezdemo_site'
+        );
+        $this->assertConfigResolverParameterValue(
+            'user_reset_password.templates.invalid_link',
+            '@yourOwnBundle/path/to/invalid_link.html.twig',
+            'ezdemo_site'
+        );
+        $this->assertConfigResolverParameterValue(
+            'user_reset_password.templates.success',
+            '@yourOwnBundle/path/to/success.html.twig',
+            'ezdemo_site'
+        );
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [IBX-215](https://jira.ez.no/browse/IBX-215) <!-- URLs to JIRA issue(s) (or N/A) -->
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

For reasons unknown, some views were lacking proper semantic configuration and were only configurable thru whole parameter name. 

#### Checklist:
- [x] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
