### PR TITLE
[Travis] Updated to Focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: focal
 sudo: required
 
 language: php


### PR DESCRIPTION
This PR updates the dist used by Travis to Focal. 

It's related to https://github.com/ezsystems/docker-php/pull/61 - Trusty has OpenSSL 1.0.2, which means that it produces errors when accessing sites using Let's Encrypt certificates. Focal uses the bug-free version (1.1.1).

Focal also has a higher Docker Compose version (1.29.2), which had a change in behaviour compared to the one used on Trusty:
```
Compose supports declaring default environment variables in an environment file named .env placed in the project directory. Docker Compose versions earlier than 1.28, load the .env file from the current working directory, where the command is executed, or from the project directory if this is explicitly set with the --project-directory option. This inconsistency has been addressed starting with +v1.28 by limiting the default .env file path to the project directory. You can use the --env-file commandline option to override the default .env and specify the path to a custom environment file.

The project directory is specified by the order of precedence:

    --project-directory flag
    Folder of the first --file flag
    Current directory
```
[ref](https://docs.docker.com/compose/env-file/)

I'm adding `--env-file=.env` to every docker-compose call to account for that.