### PR TITLE
IBX-1090: Fixed calculations and displaying of ezdate FT, as it should always be represented in UTC

### DIFF
--- a/src/lib/Templating/Twig/DateTimeExtension.php
+++ b/src/lib/Templating/Twig/DateTimeExtension.php
@@ -71,11 +71,11 @@ class DateTimeExtension extends AbstractExtension
     {
         return [
             new TwigFilter('ez_short_datetime', function ($date, $timezone = null) { return $this->format($this->shortDateTimeFormatter, $date, $timezone); }),
-            new TwigFilter('ez_short_date', function ($date, $timezone = null) { return $this->format($this->shortDateFormatter, $date, $timezone); }),
-            new TwigFilter('ez_short_time', function ($date, $timezone = null) { return $this->format($this->shortTimeFormatter, $date, $timezone); }),
+            new TwigFilter('ez_short_date', function ($date, $timezone = 'UTC') { return $this->format($this->shortDateFormatter, $date, $timezone); }),
+            new TwigFilter('ez_short_time', function ($date, $timezone = 'UTC') { return $this->format($this->shortTimeFormatter, $date, $timezone); }),
             new TwigFilter('ez_full_datetime', function ($date, $timezone = null) { return $this->format($this->fullDateTimeFormatter, $date, $timezone); }),
-            new TwigFilter('ez_full_date', function ($date, $timezone = null) { return $this->format($this->fullDateFormatter, $date, $timezone); }),
-            new TwigFilter('ez_full_time', function ($date, $timezone = null) { return $this->format($this->fullTimeFormatter, $date, $timezone); }),
+            new TwigFilter('ez_full_date', function ($date, $timezone = 'UTC') { return $this->format($this->fullDateFormatter, $date, $timezone); }),
+            new TwigFilter('ez_full_time', function ($date, $timezone = 'UTC') { return $this->format($this->fullTimeFormatter, $date, $timezone); }),
         ];
     }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | [IBX-1090](https://issues.ibexa.co/browse/IBX-1090)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes/no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

https://github.com/ezsystems/ezplatform-kernel/pull/285
https://github.com/ezsystems/ezplatform-admin-ui/pull/2033

#### Checklist:
- [x] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
