### PR TITLE
IBX-3972: Fixed password validation for reset and change password forms

### DIFF
--- a/src/bundle/Controller/PasswordChangeController.php
+++ b/src/bundle/Controller/PasswordChangeController.php
@@ -68,7 +68,7 @@ class PasswordChangeController extends Controller
     {
         /** @var \eZ\Publish\API\Repository\Values\User\User $user */
         $user = $this->tokenStorage->getToken()->getUser()->getAPIUser();
-        $form = $this->formFactory->changeUserPassword($user->getContentType());
+        $form = $this->formFactory->changeUserPassword($user->getContentType(), null, null, $user);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/bundle/Controller/PasswordResetController.php
+++ b/src/bundle/Controller/PasswordResetController.php
@@ -168,7 +168,12 @@ class PasswordResetController extends Controller
             return $view;
         }
         $userPasswordResetData = new UserPasswordResetData();
-        $form = $this->formFactory->resetUserPassword($userPasswordResetData, null, $user->getContentType());
+        $form = $this->formFactory->resetUserPassword(
+            $userPasswordResetData,
+            null,
+            $user->getContentType(),
+            $user
+        );
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/lib/Form/Factory/FormFactory.php
+++ b/src/lib/Form/Factory/FormFactory.php
@@ -9,20 +9,21 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformUser\Form\Factory;
 
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
-use EzSystems\EzPlatformUser\Form\Data\UserPasswordForgotData;
+use eZ\Publish\API\Repository\Values\User\User;
 use EzSystems\EzPlatformUser\Form\Data\UserPasswordChangeData;
+use EzSystems\EzPlatformUser\Form\Data\UserPasswordForgotData;
+use EzSystems\EzPlatformUser\Form\Data\UserPasswordForgotWithLoginData;
+use EzSystems\EzPlatformUser\Form\Data\UserPasswordResetData;
 use EzSystems\EzPlatformUser\Form\Data\UserSettingUpdateData;
 use EzSystems\EzPlatformUser\Form\Type\UserPasswordChangeType;
 use EzSystems\EzPlatformUser\Form\Type\UserPasswordForgotType;
-use EzSystems\EzPlatformUser\Form\Data\UserPasswordForgotWithLoginData;
 use EzSystems\EzPlatformUser\Form\Type\UserPasswordForgotWithLoginType;
-use EzSystems\EzPlatformUser\Form\Data\UserPasswordResetData;
 use EzSystems\EzPlatformUser\Form\Type\UserPasswordResetType;
 use EzSystems\EzPlatformUser\Form\Type\UserSettingUpdateType;
 use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Util\StringUtil;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class FormFactory
 {
@@ -45,7 +46,8 @@ class FormFactory
     public function changeUserPassword(
         ContentType $contentType,
         UserPasswordChangeData $data = null,
-        ?string $name = null
+        ?string $name = null,
+        ?User $user = null
     ): FormInterface {
         $name = $name ?: StringUtil::fqcnToBlockPrefix(UserPasswordChangeType::class);
 
@@ -53,7 +55,10 @@ class FormFactory
             $name,
             UserPasswordChangeType::class,
             $data,
-            ['content_type' => $contentType]
+            [
+                'content_type' => $contentType,
+                'user' => $user,
+            ]
         );
     }
 
@@ -102,13 +107,22 @@ class FormFactory
     public function resetUserPassword(
         UserPasswordResetData $data = null,
         ?string $name = null,
-        ContentType $contentType = null
+        ?ContentType $contentType = null,
+        ?User $user = null
     ): FormInterface {
         $name = $name ?: StringUtil::fqcnToBlockPrefix(UserPasswordResetType::class);
 
         $userContentType = $contentType ?? $data->getContentType();
 
-        return $this->formFactory->createNamed($name, UserPasswordResetType::class, $data, ['content_type' => $userContentType]);
+        return $this->formFactory->createNamed(
+            $name,
+            UserPasswordResetType::class,
+            $data,
+            [
+                'content_type' => $userContentType,
+                'user' => $user,
+            ]
+        );
     }
 
     /**

--- a/src/lib/Form/Type/UserPasswordChangeType.php
+++ b/src/lib/Form/Type/UserPasswordChangeType.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformUser\Form\Type;
 
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\User\User;
 use EzSystems\EzPlatformUser\Form\Data\UserPasswordChangeData;
 use EzSystems\EzPlatformUser\Validator\Constraints\Password;
 use Symfony\Component\Form\AbstractType;
@@ -36,6 +37,7 @@ class UserPasswordChangeType extends AbstractType
                 'constraints' => [
                     new Password([
                         'contentType' => $options['content_type'],
+                        'user' => $options['user'] ?? null,
                     ]),
                 ],
             ])
@@ -46,10 +48,12 @@ class UserPasswordChangeType extends AbstractType
             );
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setRequired('content_type');
+        $resolver->setDefined('user');
         $resolver->setAllowedTypes('content_type', ContentType::class);
+        $resolver->setAllowedTypes('user', User::class);
         $resolver->setDefaults([
             'data_class' => UserPasswordChangeData::class,
             'translation_domain' => 'forms',

--- a/src/lib/Form/Type/UserPasswordChangeType.php
+++ b/src/lib/Form/Type/UserPasswordChangeType.php
@@ -53,7 +53,7 @@ class UserPasswordChangeType extends AbstractType
         $resolver->setRequired('content_type');
         $resolver->setDefined('user');
         $resolver->setAllowedTypes('content_type', ContentType::class);
-        $resolver->setAllowedTypes('user', User::class);
+        $resolver->setAllowedTypes('user', [User::class, 'null']);
         $resolver->setDefaults([
             'data_class' => UserPasswordChangeData::class,
             'translation_domain' => 'forms',

--- a/src/lib/Form/Type/UserPasswordResetType.php
+++ b/src/lib/Form/Type/UserPasswordResetType.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace EzSystems\EzPlatformUser\Form\Type;
 
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\User\User;
 use EzSystems\EzPlatformUser\Form\Data\UserPasswordResetData;
 use EzSystems\EzPlatformUser\Validator\Constraints\Password;
 use Symfony\Component\Form\AbstractType;
@@ -30,7 +31,12 @@ class UserPasswordResetType extends AbstractType
                 'first_options' => ['label' => /** @Desc("New password") */ 'ezplatform.reset_user_password.new_password'],
                 'second_options' => ['label' => /** @Desc("Confirm password") */ 'ezplatform.reset_user_password.confirm_new_password'],
                 'constraints' => [
-                    new Password(['contentType' => $options['content_type']]),
+                    new Password(
+                        [
+                            'contentType' => $options['content_type'],
+                            'user' => $options['user'] ?? null,
+                        ]
+                    ),
                 ],
             ])
             ->add(
@@ -40,10 +46,12 @@ class UserPasswordResetType extends AbstractType
             );
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setRequired('content_type');
+        $resolver->setDefined('user');
         $resolver->setAllowedTypes('content_type', ContentType::class);
+        $resolver->setAllowedTypes('user', User::class);
         $resolver->setDefaults([
             'data_class' => UserPasswordResetData::class,
             'translation_domain' => 'forms',

--- a/src/lib/Form/Type/UserPasswordResetType.php
+++ b/src/lib/Form/Type/UserPasswordResetType.php
@@ -51,7 +51,7 @@ class UserPasswordResetType extends AbstractType
         $resolver->setRequired('content_type');
         $resolver->setDefined('user');
         $resolver->setAllowedTypes('content_type', ContentType::class);
-        $resolver->setAllowedTypes('user', User::class);
+        $resolver->setAllowedTypes('user', [User::class, 'null']);
         $resolver->setDefaults([
             'data_class' => UserPasswordResetData::class,
             'translation_domain' => 'forms',

--- a/src/lib/Validator/Constraints/Password.php
+++ b/src/lib/Validator/Constraints/Password.php
@@ -21,6 +21,9 @@ class Password extends Constraint
     /** @var \eZ\Publish\API\Repository\Values\ContentType\ContentType|null */
     public $contentType;
 
+    /** @var \eZ\Publish\API\Repository\Values\User\User|null */
+    public $user;
+
     /**
      * {@inheritdoc}
      */

--- a/src/lib/Validator/Constraints/PasswordValidator.php
+++ b/src/lib/Validator/Constraints/PasswordValidator.php
@@ -32,9 +32,13 @@ class PasswordValidator extends ConstraintValidator
 
         $passwordValidationContext = new PasswordValidationContext([
             'contentType' => $constraint->contentType,
+            'user' => $constraint->user,
         ]);
 
-        $validationErrors = $this->userService->validatePassword($value, $passwordValidationContext);
+        $validationErrors = $this->userService->validatePassword(
+            $value,
+            $passwordValidationContext
+        );
         if (!empty($validationErrors)) {
             $validationErrorsProcessor = $this->createValidationErrorsProcessor();
             $validationErrorsProcessor->processValidationErrors($validationErrors);

--- a/tests/lib/Validator/Constraint/PasswordValidatorTest.php
+++ b/tests/lib/Validator/Constraint/PasswordValidatorTest.php
@@ -11,6 +11,7 @@ namespace EzSystems\EzPlatformUser\Tests\Validator\Constraint;
 use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\User\PasswordValidationContext;
+use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\Core\FieldType\ValidationError;
 use EzSystems\EzPlatformUser\Validator\Constraints\Password;
 use EzSystems\EzPlatformUser\Validator\Constraints\PasswordValidator;
@@ -57,28 +58,37 @@ class PasswordValidatorTest extends TestCase
     {
         $password = 'pass';
         $contentType = $this->createMock(ContentType::class);
+        $user = $this->createMock(User::class);
 
         $this->userService
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('validatePassword')
-            ->willReturnCallback(function (string $actualPassword, PasswordValidationContext $actualContext) use (
-                $password,
-                $contentType
-            ): array {
-                $this->assertEquals($password, $actualPassword);
-                $this->assertInstanceOf(PasswordValidationContext::class, $actualContext);
-                $this->assertSame($contentType, $actualContext->contentType);
+            ->willReturnCallback(
+                function (string $actualPassword, PasswordValidationContext $actualContext) use (
+                    $password,
+                    $contentType,
+                    $user
+                ): array {
+                    self::assertEquals($password, $actualPassword);
+                    self::assertInstanceOf(PasswordValidationContext::class, $actualContext);
+                    self::assertSame($contentType, $actualContext->contentType);
+                    self::assertSame($user, $actualContext->user);
 
-                return [];
-            });
+                    return [];
+                }
+            );
 
         $this->executionContext
             ->expects($this->never())
             ->method('buildViolation');
 
-        $this->validator->validate($password, new Password([
-            'contentType' => $contentType,
-        ]));
+        $this->validator->validate(
+            $password,
+            new Password([
+                'contentType' => $contentType,
+                'user' => $user,
+            ])
+        );
     }
 
     public function testInvalid(): void


### PR DESCRIPTION
| Question                                  | Answer |
| ---------------------------------------- | ------------------ |
| **JIRA issue**                          | [IBX-3972](https://issues.ibexa.co/browse/IBX-3972) |
| **Soft requirement**               | ezsystems/ezplatform-kernel#363
| **Required by** | ezsystems/ezplatform-admin-ui#2094
| **Type**                                   | bug |
| **Target Ibexa version** | `v3.3`+ |
| **BC breaks**                          | no |

This PR fixes password validation for reset and change password forms. User context is required for `UserService::validatePassword` to be able to check if the old password is re-used by a user.

ezsystems/ezplatform-kernel#363 fixes the same issue, but on PHP API level, so shouldn't be strictly required as validation call is performed earlier, during `Form::handleRequest()` call.

### QA

The scopes are:
* forgot/reset password form
* expired password form (you can expire password with `ibexa:user:expire-password` command), but in fact this re-uses forgot/reset password form
* change password form in AdminUI

in all cases if reusing old password has been forbidden in Content Type `User` `ezuser` Field Settings, trying to use old password should result in properly formatted validation error. That validation is performed before PHP API call. You should not see a `ContentFieldValidationException` coming from PHP API.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly.
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review.